### PR TITLE
feat(api): migrate Groq model to GPT OSS 120B

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -43,7 +43,7 @@ DATABASE_URL=postgresql+asyncpg://postgres:postgres@db:5432/vacation_tracker
 # --- LLM & AI (GROQ) ---
 # Get from https://console.groq.com (Free tier available)
 GROQ_API_KEY=gsk_your_api_key_here
-GROQ_MODEL=llama-3.3-70b-versatile
+GROQ_MODEL=openai/gpt-oss-120b
 
 # =============================================================================
 # FLIGHT & HOTEL PROVIDER (SKIPLAGGED MCP)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ Vacation Price Tracker is a full-stack web application that tracks flight and ho
 - **Backend:** FastAPI (Python 3.12), SQLModel/PostgreSQL
 - **Orchestration:** Temporal SDK for Python (distributed workflows)
 - **Auth:** Google OAuth 2.0 only (no local passwords)
-- **LLM:** Groq (Llama 3.3) with MCP tool integration
+- **LLM:** Groq (GPT OSS 120B) with MCP tool integration
 
 ## Web File Naming
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Vacation Price Tracker is a full-stack web application designed for travelers to
 
 ## Key Features
 - **Flexible Tracking**: Track flights only, hotels only (up to 3 per trip), or both combined.
-- **AI-Powered Chat**: Natural language interface using Groq (Llama 3.3) and MCP for conversational trip management.
+- **AI-Powered Chat**: Natural language interface using Groq (GPT OSS 120B) and MCP for conversational trip management.
 - **Distributed Reliability**: Orchestrated workflows via **Temporal** for reliable price fetching.
 - **Smart Notifications**: Automated alerts via Email (MVP) and optional SMS (Future).
 - **Flexible Date Optimizer** (Phase 4): Survey date ranges to find cheaper travel windows.

--- a/apps/api/app/core/config.py
+++ b/apps/api/app/core/config.py
@@ -29,7 +29,7 @@ class Settings(BaseSettings):
 
     # LLM (Groq)
     groq_api_key: str
-    groq_model: str = "llama-3.3-70b-versatile"
+    groq_model: str = "openai/gpt-oss-120b"
 
     # Skiplagged MCP (no auth required)
     skiplagged_mcp_url: str = "https://mcp.skiplagged.com/mcp"

--- a/apps/api/tests/test_groq_client.py
+++ b/apps/api/tests/test_groq_client.py
@@ -182,12 +182,12 @@ def test_token_counter_count_tool_tokens():
 def test_groq_client_init_defaults(monkeypatch):
     """Test GroqClient initialization with defaults."""
     monkeypatch.setattr(config_module.settings, "groq_api_key", "test-key")
-    monkeypatch.setattr(config_module.settings, "groq_model", "llama-3.3-70b-versatile")
+    monkeypatch.setattr(config_module.settings, "groq_model", "openai/gpt-oss-120b")
 
     client = GroqClient()
 
     assert client._api_key == "test-key"
-    assert client._model == "llama-3.3-70b-versatile"
+    assert client._model == "openai/gpt-oss-120b"
     assert client._max_retries == 3
     assert client._client is None
 
@@ -674,7 +674,7 @@ def test_is_daily_token_limit_detects_tpd():
     mock_error = MagicMock()
     mock_error.body = {
         "error": {
-            "message": "Rate limit reached for model `llama-3.3-70b-versatile` on tokens per day (TPD): Limit 100000"
+            "message": "Rate limit reached for model `openai/gpt-oss-120b` on tokens per day (TPD): Limit 100000"
         }
     }
     assert client._is_daily_token_limit(mock_error) is True

--- a/docs/DESIGN_OVERVIEW.md
+++ b/docs/DESIGN_OVERVIEW.md
@@ -29,7 +29,7 @@ The application is a monorepo composed of containerized services orchestrated vi
 
 ```
 ┌─────────────────────────────────────────────────────────────────┐
-│                        LLM (Groq/Llama 3.3)                     │
+│                      LLM (Groq/GPT OSS 120B)                    │
 └─────────────────────────────────────────────────────────────────┘
                               │
                     ┌─────────┴─────────┐

--- a/docs/MCP_ROUTER_ARCHITECTURE.md
+++ b/docs/MCP_ROUTER_ARCHITECTURE.md
@@ -7,7 +7,7 @@ The MCP router dispatches tool calls from the LLM to the appropriate MCP servers
 ## Overview
 
 The MCP Router:
-1. Receives tool call requests from Groq (Llama 3.3) LLM
+1. Receives tool call requests from Groq (GPT OSS 120B) LLM
 2. Routes requests to the correct MCP server based on tool name
 3. Handles authentication, rate limiting, and error handling
 4. Returns results back to the LLM for response generation
@@ -31,7 +31,7 @@ The MCP Router:
 │                         ▼                               │
 │  ┌──────────────────────────────────────────────────┐   │
 │  │              Groq LLM Client                     │   │
-│  │        (Llama 3.3 with tool calling)             │   │
+│  │      (GPT OSS 120B with tool calling)            │   │
 │  └──────────────────────┬───────────────────────────┘   │
 │                         │                               │
 │                         ▼                               │
@@ -325,7 +325,7 @@ async def chat_with_tools(message: str, user_id: str, mcp_router: MCPRouter) -> 
     ]
 
     response = await client.chat.completions.create(
-        model="llama-3.3-70b-versatile",
+        model="openai/gpt-oss-120b",
         messages=[{"role": "user", "content": message}],
         tools=tool_definitions,
         tool_choice="auto",

--- a/docs/PROJECT_PLAN.md
+++ b/docs/PROJECT_PLAN.md
@@ -58,7 +58,7 @@ All flight and hotel data is provided by the **Skiplagged MCP** at `https://mcp.
 **Goal:** Conversational control using Groq.
 
 ### LLM Setup
-- [x] Groq API client configuration (Llama 3.3 70B)
+- [x] Groq API client configuration (GPT OSS 120B)
 - [x] System prompts for travel assistant persona
 - [x] Tool-calling configuration for MCP integration
 

--- a/docs/phased-plans/PHASE_2_PLAN.md
+++ b/docs/phased-plans/PHASE_2_PLAN.md
@@ -1,6 +1,6 @@
 # Phase 2: Chat & LLM Integration
 
-**Goal:** Conversational trip management using Groq (Llama 3.3) with MCP tool integration.
+**Goal:** Conversational trip management using Groq (GPT OSS 120B) with MCP tool integration.
 
 **Prerequisites:** Phase 1 complete (OAuth, Trip CRUD, Dashboard, Temporal workflows)
 
@@ -22,7 +22,7 @@
   class GroqClient:
       def __init__(self):
           self.client = Groq(api_key=settings.GROQ_API_KEY)
-          self.model = settings.GROQ_MODEL  # llama-3.3-70b-versatile
+          self.model = settings.GROQ_MODEL  # openai/gpt-oss-120b
 
       async def chat(
           self,


### PR DESCRIPTION
## Why

Groq is deprecating **Llama 3.3 70B Versatile** (deprecated 17 June 2026, decommissioned **16 August 2026**). After that date requests to the model will no longer be served. This migrates the app to Groq's recommended replacement, **`openai/gpt-oss-120b`** (GPT OSS 120B).

Of the three Groq decommission notices received, this is the **only affected model used by the codebase** — `llama-3.1-8b-instant` and `llama-4-scout-17b` are not referenced anywhere.

## Changes

- **`apps/api/app/core/config.py`** — default `groq_model` → `openai/gpt-oss-120b` (single source of truth read by `GroqClient`)
- **`.env.example`** — `GROQ_MODEL` default updated
- **`apps/api/tests/test_groq_client.py`** — test expectations updated for the new model id
- **Docs** — `CLAUDE.md`, `README.md`, `docs/PROJECT_PLAN.md`, `docs/MCP_ROUTER_ARCHITECTURE.md`, `docs/DESIGN_OVERVIEW.md`, `docs/phased-plans/PHASE_2_PLAN.md` (ASCII diagram alignment preserved)

The model id is overridable via the `GROQ_MODEL` env var, so deployments can pin a different id without code changes.

## Testing

- `uv run pytest apps/api/tests/test_groq_client.py` — **40 passed**

## Note for reviewer

Confirm `openai/gpt-oss-120b` is the exact model id available on the target Groq tier before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0174Yg4PYk5srdb9K9cSATbz

---
_Generated by [Claude Code](https://claude.ai/code/session_0174Yg4PYk5srdb9K9cSATbz)_