### PR TITLE
fix(web): emit standalone output so the prod image builds

### DIFF
--- a/.github/workflows/build-prod-images.yml
+++ b/.github/workflows/build-prod-images.yml
@@ -28,12 +28,17 @@ jobs:
           - app: web
             context: apps/web
             dockerfile: apps/web/Dockerfile
+            # NEXT_PUBLIC_* must be baked at build time (inlined into the client
+            # bundle); a runtime env var can't reach the browser.
+            build_args: NEXT_PUBLIC_API_URL=https://vacation-price-tracker.ethanasm.me
           - app: api
             context: .
             dockerfile: apps/api/Dockerfile
+            build_args: ""
           - app: worker
             context: .
             dockerfile: apps/worker/Dockerfile
+            build_args: ""
     steps:
       - uses: actions/checkout@v4
 
@@ -62,6 +67,7 @@ jobs:
           file: ${{ matrix.dockerfile }}
           target: production
           push: true
+          build-args: ${{ matrix.build_args }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha,scope=${{ matrix.app }}

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -23,11 +23,17 @@ CMD ["sh", "-c", "if [ -f /app/certs/localhost-key.pem ]; then node server.js; e
 FROM base AS builder
 
 COPY package.json pnpm-lock.yaml* ./
-RUN pnpm install 2>/dev/null || echo "No package.json yet"
+RUN pnpm install
 
 COPY . .
 
-RUN pnpm run build 2>/dev/null || echo "No build script yet"
+# NEXT_PUBLIC_* values are inlined into the client bundle at build time, so the
+# API base URL must be set here — a runtime env var would not reach the browser.
+# Defaults to the dev URL; CI passes the prod origin via --build-arg.
+ARG NEXT_PUBLIC_API_URL=https://localhost:8000
+ENV NEXT_PUBLIC_API_URL=${NEXT_PUBLIC_API_URL}
+
+RUN pnpm run build
 
 # Production stage
 FROM base AS production
@@ -39,9 +45,10 @@ ENV NODE_ENV=production \
 RUN addgroup --system --gid 1001 nodejs && \
     adduser --system --uid 1001 nextjs
 
-COPY --from=builder /app/public ./public 2>/dev/null || true
-COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./ 2>/dev/null || true
-COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static 2>/dev/null || true
+# Next standalone output: server.js + minimal node_modules, plus static assets.
+COPY --from=builder /app/public ./public
+COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
+COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
 
 USER nextjs
 

--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -1,6 +1,9 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  reactStrictMode: true
+  reactStrictMode: true,
+  // Emit a self-contained server (.next/standalone/server.js) so the prod
+  // Docker image can run `node server.js` without a full node_modules install.
+  output: "standalone"
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Summary

The first real build of the prod **web** image failed in `Build Prod Images`:
```
ERROR: failed to compute cache key: ".next/static": not found
```
The production stage copies Next.js standalone output that was never generated — `next.config.mjs` had no `output` mode, and the builder swallowed any failure with `2>/dev/null || echo`. The `COPY ... 2>/dev/null || true` lines were also invalid (shell syntax in a `COPY`).

Fixes:
- **`next.config.mjs`** → `output: "standalone"` so `next build` emits `.next/standalone/server.js`. Verified in an isolated `apps/web` build (the Docker build context) that this lands **flat** at `.next/standalone/server.js` + `.next/static`.
- **`apps/web/Dockerfile`** → build loudly (drop `2>/dev/null || echo`/`|| true`), valid `COPY` lines for standalone output, and an `ARG NEXT_PUBLIC_API_URL` baked at build time — Next inlines `NEXT_PUBLIC_*` into the **client** bundle (`lib/api.ts`, `use-sse.ts`, …), so a runtime env var would never reach the browser; it'd fall back to `localhost:8000`.
- **`build-prod-images.yml`** → pass `NEXT_PUBLIC_API_URL=https://vacation-price-tracker.ethanasm.me` as a build-arg for the web image (empty for api/worker).

## Test plan

- [x] `next build` (isolated `apps/web` context) produces flat `.next/standalone/server.js` + `.next/static`
- [x] Prod API URL inlined into the client bundle
- [x] `build-prod-images.yml` parses
- [ ] `Build Prod Images` green on merge (web image pushes)
- [ ] Deploy → `https://vacation-price-tracker.ethanasm.me` serves the app and hits the API at the baked origin

> Note: full local `docker build` is blocked in the sandbox (Alpine `apk` TLS proxy), so the build was validated via an isolated `next build` reproducing the Docker context. CI's network reaches past the base stage already, so the standalone output is the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CLU2qzji7MCM2UREz8yaZR

---
_Generated by [Claude Code](https://claude.ai/code/session_012iAa5gbXg1jiGBVWgJcnYj)_