### PR TITLE
feat: adopt showbook deploy-safety, docs, and skill patterns

### DIFF
--- a/.claude/skills/bug-fixing/SKILL.md
+++ b/.claude/skills/bug-fixing/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: bug-fixing
+description: Use when fixing a bug in the vacation-price-tracker codebase. Verifies locally without running Playwright E2E (slow/flaky in the sandbox), then opens a PR and subscribes to CI activity so failures from GitHub Actions can be triaged and patched in-loop.
+---
+
+# Bug fixing
+
+## Overview
+
+Playwright E2E is expensive in the local/web sandbox and flakes on environment
+differences (browser binaries, ports, the Docker stack). The faster, more
+reliable loop is:
+
+1. Reproduce + fix locally.
+2. Verify with the **non-E2E** gate (`pnpm verify`, targeted tests).
+3. Push the branch, open a PR, let GitHub Actions run the full suite.
+4. Subscribe to PR activity and react to CI failures as they arrive.
+
+Do **not** run `pnpm verify --e2e` or `RUN_E2E=1` in the sandbox unless the user
+explicitly asks.
+
+## When to use
+
+- The user reports a bug or regression and wants it fixed.
+- A failing test (unit, integration, or E2E) needs investigation and repair.
+- A PR has CI failures that need to be patched.
+
+## When NOT to use
+
+- Pure refactors with no bug attached.
+- Production-only investigations with no code change yet — start with
+  `debugging-prod`.
+
+## Loop
+
+### 1. Reproduce and fix
+
+- Read the root `CLAUDE.md` and the relevant per-app guide (`apps/web/CLAUDE.md`,
+  `apps/api/CLAUDE.md`, `apps/worker/CLAUDE.md`) before editing.
+- Write or extend a test that fails because of the bug, then make it pass.
+- Keep the fix minimal — no surrounding cleanup, no speculative refactors.
+
+### 2. Verify locally (no E2E)
+
+Run only what's relevant to the change:
+
+```bash
+# Python (api/worker) — note the 95% coverage gate
+pnpm nx run api:test:coverage
+pnpm nx run worker:test:coverage
+# Web
+pnpm nx run web:test
+# Full local gate (build + lint + typecheck + test:coverage + audits, no E2E)
+pnpm verify
+```
+
+Skip `pnpm verify --e2e` and any Playwright invocation in the sandbox — CI runs
+the full suite, that's the point of step 3.
+
+> Gotcha: a local `.env` with `MOCK_SKIPLAGGED_API=true` makes Nx-run worker
+> tests fail (Nx auto-loads `.env`, flipping the worker into mock mode). CI has
+> no `.env`, so it's green there. Run with `MOCK_SKIPLAGGED_API=false` locally.
+
+### 3. Hand off to creating-prs
+
+Commit on the assigned development branch, then invoke the `creating-prs` skill —
+it owns merge-main, push, PR creation, PR-activity subscription, the CI-failure →
+fix → re-push loop, and the `debug-web` hand-off when the diff touches UI.
+
+## Anti-patterns
+
+- Running `pnpm verify --e2e` "just to be sure" before pushing — don't.
+- Skipping the PR and asking the user to run E2E themselves — open the PR; CI is
+  the loop.
+- Pushing speculative fixes without first reading the CI failure log.
+- Using `--no-verify` to bypass a failing hook — fix the underlying issue.

--- a/.claude/skills/creating-prs/SKILL.md
+++ b/.claude/skills/creating-prs/SKILL.md
@@ -99,7 +99,43 @@ body via `https://github.com/ethanasm/vacation-price-tracker/raw/pr-screenshots/
 — never commit screenshots to `main` or the PR branch. If nothing matches, skip
 this step.
 
-### 5. Subscribe to CI activity
+### 5. Peer-review the PR with an Opus subagent
+
+Once the PR is open, spawn a **subagent on the Opus model** (`Agent` with
+`model: "opus"`) to peer-review the diff and **post its findings as a single PR
+comment**. This is a fresh-eyes review of the shipped change, separate from any
+local `/code-review` you ran while writing it. Run it in the background
+(`run_in_background: true`) so CI and the rest of the loop proceed in parallel;
+fold its findings in when it returns.
+
+Give the subagent:
+
+- the PR number + repo (`ethanasm/vacation-price-tracker`) and that the branch is
+  checked out locally, so it can read the diff via
+  `mcp__github__pull_request_read` (method `get_diff`) **and** the full files
+  locally for context;
+- a short description of what the change does and the riskiest areas to
+  scrutinize — Temporal workflow/activity job + retry semantics, Alembic
+  migrations + FK/cascade behavior, query correctness (including the
+  `/v1/admin/sql` guard and SQLModel queries), cross-surface parity (web ↔ api
+  schemas), edge/empty/error states, and test coverage of the key invariants
+  (95% Python gate) — correctness and robustness, not style nits;
+- the deliverable: a structured verdict (approve / approve-with-nits /
+  request-changes) plus findings grouped by severity (P0 / P1 / P2), each with a
+  `file:line` reference and a concrete recommendation;
+- instructions to **post the review as ONE consolidated comment** via
+  `mcp__github__add_issue_comment` (prefixed `## Peer review (automated)`), to
+  **not** post multiple comments, and to **not** modify any code. (Posting a
+  review comment is the point of this step, so the external-write is intended —
+  note that to the user when you relay results.)
+
+When it returns, **you (the main agent) own the findings**: fix every P0 and P1,
+and fix P2s at your discretion (lean toward fixing). Re-run the relevant non-E2E
+gate (`pnpm verify` or the targeted Nx task) and push. Surface anything you're
+deliberately not fixing (with the reason) to the user rather than dropping it
+silently.
+
+### 6. Subscribe to CI activity
 
     mcp__github__subscribe_pr_activity { owner: "ethanasm", repo: "vacation-price-tracker", pullNumber: <n> }
 
@@ -107,7 +143,7 @@ Events arrive wrapped in `<github-webhook-activity>` tags. CI for this repo runs
 `nextjs.yml` (web build/lint/test), `python.yml` (api + worker), and
 `sonarqube.yml`. While CI runs you can move on to other work.
 
-### 6. React to events
+### 7. React to events
 
 When a failure event arrives:
 

--- a/.claude/skills/debug-web/SKILL.md
+++ b/.claude/skills/debug-web/SKILL.md
@@ -98,6 +98,39 @@ against the suspect route and read the terminal.
 **Compare light vs dark** — run both `--project=light` and `--project=dark` for
 the same `DEBUG_ROUTE`; the two PNGs are suffixed by project name.
 
+## Capturing review-quality screenshots for a PR
+
+When the capture is **review material for a PR** (the `creating-prs` hand-off),
+the frame is a quality gate, not decoration. Get the *preferred, fully-rendered*
+state — these are the ways it goes wrong:
+
+- **Capture the rendered state, not a loading skeleton (the #1 failure).** The
+  debug spec waits for `networkidle`, but VPT routes fetch client-side (trips load
+  via the api client, `/trips/<id>` price history, `/chat` SSE) — a slow query can
+  still freeze a skeleton. For those, block on the actual content before the shot,
+  e.g. `await expect(page.locator('[data-trip-card]').first()).toBeVisible({ timeout: 30_000 })`
+  then a short settle, rather than trusting `networkidle` alone.
+- **Seed the data the surface needs.** A render-wait still captures an *empty
+  state* if the fixture user has no rows. The `e2e` auth state is a logged-in
+  user — make sure that user actually has trips / price snapshots / the section
+  your change touches. If you can't seed a section, say so in the PR body instead
+  of shipping a partial capture.
+- **Save each capture the instant it's taken.** Playwright wipes its output
+  (`apps/web/e2e/screenshots/`, `test-results/`) at the start of every run, so copy
+  the "after" PNG to a scratch dir (the session scratchpad) *before* you run the
+  "before" pass — otherwise the before-run silently deletes your after and a later
+  step recovers a stale/wrong PNG.
+- **Before/after whenever the change is visual** (spacing, sizing, color, copy,
+  layout). Screenshot HEAD, copy it aside, then `git checkout HEAD^ -- <changed
+  files>`, re-shoot, and restore — never `git stash` on a clean tree (it no-ops
+  and yields two "after" shots).
+- **Actually open every PNG before posting.** A green Playwright run only proves
+  the spec passed — it does **not** prove the frame is the one you want. `Read`
+  each capture and confirm it shows the rendered preferred state (right route,
+  real data, not a skeleton / spinner / empty state / error / blank page). If it
+  doesn't, fix the wait/seed/selector and re-capture before posting. Posting a
+  capture you never opened is the most common way this ships misleading material.
+
 ## Debugging prod instead?
 
 This skill is for the **local** UI (you have the dev stack and a browser). For a

--- a/.env.example
+++ b/.env.example
@@ -36,6 +36,15 @@ SECRET_KEY=generate-a-random-secret-key-here
 GOOGLE_CLIENT_ID=your-google-client-id.apps.googleusercontent.com
 GOOGLE_CLIENT_SECRET=your-google-client-secret
 
+# --- SIGN-IN ALLOWLIST (optional) ---
+# Gate who can sign in. Comma-separated. If BOTH are blank, sign-up is open;
+# if EITHER is set, the OAuth callback denies anyone not on the list (they are
+# redirected to /access-denied). Domains match the part after "@".
+#   AUTH_ALLOWED_EMAILS=me@gmail.com,friend@gmail.com
+#   AUTH_ALLOWED_DOMAINS=mycompany.com
+AUTH_ALLOWED_EMAILS=
+AUTH_ALLOWED_DOMAINS=
+
 # --- DATABASE ---
 # For Docker Compose setup
 DATABASE_URL=postgresql+asyncpg://postgres:postgres@db:5432/vacation_tracker

--- a/.env.prod.example
+++ b/.env.prod.example
@@ -26,6 +26,13 @@ SECRET_KEY=change-me-openssl-rand-hex-32
 GOOGLE_CLIENT_ID=your-google-client-id.apps.googleusercontent.com
 GOOGLE_CLIENT_SECRET=your-google-client-secret
 
+# --- SIGN-IN ALLOWLIST ---
+# Strongly recommended in prod: restrict who can sign in. Comma-separated.
+# Both blank → anyone with a Google account can sign up. If either is set, only
+# matching emails/domains are admitted (others land on /access-denied).
+AUTH_ALLOWED_EMAILS=you@gmail.com
+AUTH_ALLOWED_DOMAINS=
+
 # --- PUBLIC URLS / CORS ---
 # Single public web origin (Cloudflare Tunnel / custom domain). BACKEND_URL is
 # baked into the web image as NEXT_PUBLIC_API_URL.

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -66,11 +66,27 @@ jobs:
           pnpm prod:pull
           pnpm prod:up
 
+      - name: Pre-migration DB backup
+        working-directory: /opt/vacation-price-tracker
+        # Snapshot the DB before migrations so a bad migration has a recovery
+        # point. Writes backups/pre-migrate-<sha>.dump. A backup we can't take
+        # is exactly when we least want to migrate, so this is fatal.
+        env:
+          DEPLOY_SHA: ${{ steps.sha.outputs.sha }}
+        run: pnpm prod:db:backup
+
       - name: Run database migrations
         working-directory: /opt/vacation-price-tracker
         env:
           IMAGE_TAG: ${{ steps.sha.outputs.sha }}
         run: pnpm prod:db:migrate
+
+      - name: Post-deploy health gate
+        working-directory: /opt/vacation-price-tracker
+        # Block "deploy succeeded" until the api reports ready (DB + Redis +
+        # Temporal all reachable). /ready returns 503 until they are; the curl
+        # retries cover the boot/migration window.
+        run: pnpm prod:health:ready
 
       - name: Prune dangling images
         run: docker image prune -f

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .env
 .env.prod
 .env.*.local
+/backups
 /node_modules
 .coverage
 /apps/*/coverage*

--- a/apps/api/app/core/auth_allowlist.py
+++ b/apps/api/app/core/auth_allowlist.py
@@ -1,0 +1,43 @@
+"""Sign-in allowlist — gate Google sign-in by email and/or domain.
+
+Mirrors showbook's `lib/auth-allowlist.ts`. Config comes from the env-driven
+`AUTH_ALLOWED_EMAILS` / `AUTH_ALLOWED_DOMAINS` (comma-separated). Both unset →
+open sign-up. If either is set → the OAuth callback denies anyone not on the
+list. Read on every callback (no cache), so updating the env takes effect on
+the next sign-in.
+"""
+
+from __future__ import annotations
+
+
+def parse_allowlist(raw: str | None) -> list[str]:
+    """Split a comma-separated env value into a lowercased, trimmed list."""
+    return [item.strip().lower() for item in (raw or "").split(",") if item.strip()]
+
+
+def is_email_allowed(email: str | None, *, emails: list[str], domains: list[str]) -> bool:
+    """True if no allowlist is configured, or the email matches one entry."""
+    if not emails and not domains:
+        return True
+    if not email:
+        return False
+    normalized = email.lower()
+    if normalized in emails:
+        return True
+    return any(normalized.endswith("@" + domain) for domain in domains)
+
+
+def should_allow_sign_in(
+    *,
+    email: str | None,
+    email_verified: bool | None,
+    emails: list[str],
+    domains: list[str],
+) -> bool:
+    """Combined gate. Reject unverified Google accounts (a Workspace send-as /
+    external alias can present an arbitrary `email` with `email_verified: false`,
+    which would otherwise spoof a whitelisted address), then defer to the
+    allowlist."""
+    if email_verified is False:
+        return False
+    return is_email_allowed(email, emails=emails, domains=domains)

--- a/apps/api/app/core/config.py
+++ b/apps/api/app/core/config.py
@@ -24,6 +24,11 @@ class Settings(BaseSettings):
     google_client_id: str
     google_client_secret: str
 
+    # Sign-in allowlist (comma-separated). Both blank → open sign-up; if either
+    # is set, the OAuth callback denies anyone not on the list.
+    auth_allowed_emails: str = ""
+    auth_allowed_domains: str = ""
+
     # Database
     database_url: str
 

--- a/apps/api/app/main.py
+++ b/apps/api/app/main.py
@@ -62,9 +62,12 @@ if os.getenv("DEBUG") == "1":
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     """Initialize resources on startup, cleanup on shutdown."""
-    # Create database tables
-    async with async_engine.begin() as conn:
-        await conn.run_sync(SQLModel.metadata.create_all)
+    # Create database tables in dev only. In production Alembic owns the schema
+    # (`pnpm prod:db:migrate`); auto-creating here would race migrations and
+    # leave the DB with tables but no alembic_version stamp.
+    if not settings.is_production:
+        async with async_engine.begin() as conn:
+            await conn.run_sync(SQLModel.metadata.create_all)
 
     # Initialize Temporal client
     await init_temporal_client()

--- a/apps/api/app/routers/auth.py
+++ b/apps/api/app/routers/auth.py
@@ -10,6 +10,7 @@ from sqlalchemy import delete
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.future import select
 
+from app.core.auth_allowlist import parse_allowlist, should_allow_sign_in
 from app.core.cache_keys import CacheKeys, CacheTTL
 from app.core.config import settings
 from app.core.constants import CookieNames, JWTClaims, TokenType
@@ -89,6 +90,16 @@ async def google_auth_callback(request: Request, db: AsyncSession = Depends(get_
 
     if not google_sub or not email:
         raise BadRequestError("Missing required user info from Google.")
+
+    # Gate sign-in against the configured allowlist (open sign-up if unset).
+    if not should_allow_sign_in(
+        email=email,
+        email_verified=user_info.get("email_verified"),
+        emails=parse_allowlist(settings.auth_allowed_emails),
+        domains=parse_allowlist(settings.auth_allowed_domains),
+    ):
+        logger.warning("Sign-in denied by allowlist: email=%s", email)
+        return RedirectResponse(url=f"{settings.frontend_url}/access-denied")
 
     # Find existing user or create a new one
     result = await db.execute(select(User).where(User.google_sub == google_sub))

--- a/apps/api/tests/test_auth.py
+++ b/apps/api/tests/test_auth.py
@@ -136,6 +136,29 @@ class TestGoogleOAuthCallback:
         assert response.status_code == 400
         assert response.json()["detail"] == "Missing required user info from Google."
 
+    def test_callback_denied_by_allowlist_redirects(self, client, monkeypatch):
+        """A non-allowlisted email is redirected to /access-denied, not logged in."""
+        monkeypatch.setattr(settings, "auth_allowed_emails", "allowed@example.com")
+        monkeypatch.setattr(settings, "auth_allowed_domains", "")
+        monkeypatch.setattr(
+            auth_module.oauth.google,
+            "authorize_access_token",
+            AsyncMock(
+                return_value={
+                    "userinfo": {
+                        "sub": "google_user_denied",
+                        "email": "stranger@evil.com",
+                        "email_verified": True,
+                    }
+                }
+            ),
+        )
+
+        response = client.get("/v1/auth/google/callback", follow_redirects=False)
+
+        assert response.status_code == 307
+        assert response.headers["location"].endswith("/access-denied")
+
     @pytest.mark.asyncio
     async def test_callback_success_creates_user(self, test_session, mock_redis, monkeypatch):
         """Test successful OAuth callback creates user and redirects."""

--- a/apps/api/tests/test_auth_allowlist.py
+++ b/apps/api/tests/test_auth_allowlist.py
@@ -1,0 +1,69 @@
+"""Tests for the sign-in allowlist gate."""
+
+from app.core.auth_allowlist import (
+    is_email_allowed,
+    parse_allowlist,
+    should_allow_sign_in,
+)
+
+
+class TestParseAllowlist:
+    def test_none_and_empty(self):
+        assert parse_allowlist(None) == []
+        assert parse_allowlist("") == []
+        assert parse_allowlist("   ") == []
+
+    def test_splits_trims_lowercases_and_drops_blanks(self):
+        assert parse_allowlist(" A@X.com, , B@Y.COM ,") == ["a@x.com", "b@y.com"]
+
+
+class TestIsEmailAllowed:
+    def test_open_signup_when_no_allowlist(self):
+        assert is_email_allowed("anyone@example.com", emails=[], domains=[]) is True
+        # Even a missing email is allowed when nothing is configured.
+        assert is_email_allowed(None, emails=[], domains=[]) is True
+
+    def test_missing_email_denied_when_allowlist_set(self):
+        assert is_email_allowed(None, emails=["a@x.com"], domains=[]) is False
+
+    def test_exact_email_match_case_insensitive(self):
+        assert is_email_allowed("A@X.com", emails=["a@x.com"], domains=[]) is True
+
+    def test_domain_match(self):
+        assert is_email_allowed("someone@team.io", emails=[], domains=["team.io"]) is True
+
+    def test_no_match(self):
+        assert is_email_allowed("nope@other.com", emails=["a@x.com"], domains=["team.io"]) is False
+
+
+class TestShouldAllowSignIn:
+    def test_unverified_email_denied(self):
+        assert (
+            should_allow_sign_in(
+                email="a@x.com", email_verified=False, emails=["a@x.com"], domains=[]
+            )
+            is False
+        )
+
+    def test_verified_allowed(self):
+        assert (
+            should_allow_sign_in(
+                email="a@x.com", email_verified=True, emails=["a@x.com"], domains=[]
+            )
+            is True
+        )
+
+    def test_verified_none_defers_to_allowlist(self):
+        # Google normally sends email_verified; treat absent as not-false.
+        assert (
+            should_allow_sign_in(
+                email="a@x.com", email_verified=None, emails=[], domains=[]
+            )
+            is True
+        )
+        assert (
+            should_allow_sign_in(
+                email="nope@y.com", email_verified=None, emails=["a@x.com"], domains=[]
+            )
+            is False
+        )

--- a/apps/web/src/__tests__/access-denied-page.test.tsx
+++ b/apps/web/src/__tests__/access-denied-page.test.tsx
@@ -1,0 +1,18 @@
+import { render, screen } from "@testing-library/react";
+import AccessDeniedPage from "../app/access-denied/page";
+
+describe("AccessDeniedPage", () => {
+  it("shows the allowlist denial message and a link home", () => {
+    render(<AccessDeniedPage />);
+
+    expect(
+      screen.getByRole("heading", { name: /access denied/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/isn't on the allowlist/i),
+    ).toBeInTheDocument();
+
+    const back = screen.getByRole("link", { name: /back to sign in/i });
+    expect(back).toHaveAttribute("href", "/");
+  });
+});

--- a/apps/web/src/app/access-denied/page.tsx
+++ b/apps/web/src/app/access-denied/page.tsx
@@ -1,0 +1,30 @@
+import Link from "next/link";
+import { ShieldX } from "lucide-react";
+
+/**
+ * Shown when the OAuth callback rejects a sign-in that isn't on the
+ * AUTH_ALLOWED_EMAILS / AUTH_ALLOWED_DOMAINS allowlist. The api redirects here
+ * (`{FRONTEND_URL}/access-denied`) instead of creating a session.
+ */
+export default function AccessDeniedPage() {
+  return (
+    <main className="flex min-h-screen flex-col items-center justify-center gap-6 px-6 text-center">
+      <div className="flex h-16 w-16 items-center justify-center rounded-full bg-destructive/10 text-destructive">
+        <ShieldX size={32} aria-hidden="true" />
+      </div>
+      <div className="space-y-2">
+        <h1 className="text-2xl font-semibold">Access denied</h1>
+        <p className="max-w-md text-muted-foreground">
+          This Google account isn&apos;t on the allowlist. If you think it should
+          be, reach out to the owner.
+        </p>
+      </div>
+      <Link
+        href="/"
+        className="text-sm font-medium text-primary underline-offset-4 hover:underline"
+      >
+        Back to sign in
+      </Link>
+    </main>
+  );
+}

--- a/docs/GUARDRAILS.md
+++ b/docs/GUARDRAILS.md
@@ -1,0 +1,73 @@
+# Guardrails
+
+The canonical list of safety / cost / abuse limits enforced by Vacation Price
+Tracker itself — the things that protect a deployment from accidental or hostile
+cost-runaway, abuse, or data exposure. Repository-level controls (branch
+protection, secret scanning, Dependabot) live in the GitHub Settings UI, outside
+this file.
+
+Most state for rate limiting and idempotency lives in **Redis** (24h TTLs),
+shared across the api processes. Limits are per-user (by authenticated user id)
+or per-IP where noted.
+
+---
+
+## Auth and session gates
+
+| Gate | Where | Behaviour |
+|------|-------|-----------|
+| Google OAuth only | `apps/api/app/routers/auth.py` | No local passwords. Users are keyed by `google_sub`; the callback is `<BACKEND_URL>/v1/auth/google/callback`. |
+| JWT session | `apps/api/app/core/config.py` | Access token 15 min (`access_token_expire_minutes`), refresh 7 days (`refresh_token_expire_days`), HS256 signed with `SECRET_KEY`. |
+| CORS allowlist | `core/config.py` (`cors_allowed_origins_list`) | Empty by default; in prod set `CORS_ALLOWED_ORIGINS` to the single web origin. |
+| CSRF | `apps/api/app/middleware/csrf.py` | State-changing requests require a CSRF token. `/v1/admin/` is exempt (it uses a bearer token instead). |
+
+---
+
+## `POST /v1/admin/sql` — read-only SQL endpoint
+
+Defense-in-depth (`apps/api/app/routers/admin.py`, `core/admin_query.py`):
+
+| Layer | Limit |
+|-------|-------|
+| Bearer token | Timing-safe compare against `ADMIN_QUERY_TOKEN`; endpoint **disabled** unless the token is set and ≥ 32 chars. |
+| Read-only txn | Postgres `SET TRANSACTION READ ONLY`; every query is rolled back regardless of dialect. |
+| Statement timeout | `SET LOCAL statement_timeout = 3000` (3 s) per query. |
+| Prefix allowlist | Only `SELECT`/`WITH`/`EXPLAIN`/`SHOW`/`TABLE`/`VALUES`, single statement. |
+| Row cap | 1000 rows max returned. |
+| Per-IP rate limit | 30 requests / 60 s (Redis, fails open — token still required). |
+| Connection cap | Dedicated engine `pool_size=2`, caps blast radius of a leaked token. Prefer a read-only role via `ADMIN_QUERY_DATABASE_URL`. |
+
+---
+
+## Per-user / per-IP rate limits
+
+| Limit | Default | Source |
+|-------|---------|--------|
+| API requests / minute | 100 | `rate_limit_per_minute` |
+| Chat (LLM) messages / minute | 10 | `chat_rate_limit_per_minute` — Groq calls are expensive |
+| Trips per user | 10 | `MAX_TRIPS_PER_USER` (`create_trip` rejects beyond this) |
+
+---
+
+## Idempotency and provider cost control
+
+| Gate | Where | Behaviour |
+|------|-------|-----------|
+| Trip creation idempotency | `apps/api/app/middleware/idempotency.py` | `X-Idempotency-Key` required for `POST /v1/trips`; stored in Redis with a 24h TTL (at-least-once safe). |
+| Skiplagged response cache | `apps/api/app/clients/skiplagged.py` | 24h Redis cache for identical route/date queries — courtesy + cost. `MOCK_SKIPLAGGED_API=true` returns mock data in dev. |
+| Skiplagged 429 handling | `apps/worker/worker/activities/price_check.py` | The tracking worker backs off on 429 and writes a **partial** snapshot rather than failing the run. |
+| Post-fetch filtering | worker | Airline / room-type / view filters are applied in-memory (Skiplagged supports neither), bounded by `max_pages=4` (~300 results). |
+
+---
+
+## Operational guards
+
+- **Prod DB is owned by the FastAPI app + Alembic.** Migrations run in-container
+  (`pnpm prod:db:migrate`); the app no longer auto-creates tables in production
+  (Alembic is the source of truth).
+- **Pre-migration backup.** `deploy.yml` runs `pnpm prod:db:backup` (pg_dump,
+  custom format) into `backups/pre-migrate-<sha>.dump` before every migration.
+- **Post-deploy health gate.** `pnpm prod:health:ready` curls `/ready` (DB +
+  Redis + Temporal) with retries; a deploy isn't "done" until it passes.
+- **Loopback-only binds.** The prod stack publishes every port on `127.0.0.1`;
+  ingress is fronted by a Cloudflare Tunnel that terminates TLS.

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -1,0 +1,36 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+If you've found a security issue in Vacation Price Tracker, please **do not**
+open a public GitHub issue. Instead, report it privately via GitHub's
+["Report a vulnerability"](https://github.com/ethanasm/vacation-price-tracker/security/advisories/new)
+flow on the repository's Security tab.
+
+I'll acknowledge the report within a few days and follow up with next steps.
+
+## Scope
+
+Only the latest commit on `main` is considered in scope. There is no bug bounty —
+this is a personal project and reports are accepted in good faith.
+
+In-scope examples:
+
+- Authentication / authorization bugs (IDORs, session/JWT handling, OAuth
+  callback handling, CSRF).
+- Server-side request forgery, command injection, SQL injection.
+- Bypasses of the read-only `POST /v1/admin/sql` endpoint guard (write through a
+  read-only transaction, statement-timeout bypass, token compare weaknesses).
+- Cost-abuse vectors against paid/again-throttled upstreams (Groq LLM, the
+  Skiplagged MCP). See [`GUARDRAILS.md`](./GUARDRAILS.md) for existing caps.
+- Secrets accidentally committed to the repository.
+
+Out of scope:
+
+- Issues that require a self-hoster to misconfigure their own deployment
+  (e.g. setting `ADMIN_QUERY_TOKEN` to a weak value, or pointing
+  `ADMIN_QUERY_DATABASE_URL` at a writable role).
+- Denial of service against a self-hosted instance from an authenticated user.
+- Findings against third-party dependencies with no working exploit path through
+  this app. (Dependency CVEs are tracked separately via `pnpm audit` / `pip-audit`
+  in CI.)

--- a/infra/docker-compose.prod.yml
+++ b/infra/docker-compose.prod.yml
@@ -25,6 +25,7 @@ x-logging: &default-logging
 services:
   db:
     image: postgres:15-alpine
+    container_name: vpt-prod-db
     restart: unless-stopped
     environment:
       POSTGRES_USER: postgres
@@ -43,6 +44,7 @@ services:
 
   redis:
     image: redis:7-alpine
+    container_name: vpt-prod-redis
     restart: unless-stopped
     ports:
       - "127.0.0.1:6381:6379"
@@ -57,6 +59,7 @@ services:
 
   temporal:
     image: temporalio/auto-setup:latest
+    container_name: vpt-prod-temporal
     restart: unless-stopped
     environment:
       DB: postgres12
@@ -79,6 +82,7 @@ services:
 
   api:
     image: ghcr.io/ethanasm/vpt-api:${IMAGE_TAG:-latest}
+    container_name: vpt-prod-api
     restart: unless-stopped
     env_file: ../.env.prod
     environment:
@@ -106,6 +110,7 @@ services:
 
   worker:
     image: ghcr.io/ethanasm/vpt-worker:${IMAGE_TAG:-latest}
+    container_name: vpt-prod-worker
     restart: unless-stopped
     env_file: ../.env.prod
     environment:
@@ -125,7 +130,9 @@ services:
 
   web:
     image: ghcr.io/ethanasm/vpt-web:${IMAGE_TAG:-latest}
+    container_name: vpt-prod-web
     restart: unless-stopped
+    stop_grace_period: 30s
     environment:
       NEXT_PUBLIC_API_URL: ${BACKEND_URL}
       SECRET_KEY: ${SECRET_KEY:?SECRET_KEY is required}

--- a/package.json
+++ b/package.json
@@ -47,6 +47,8 @@
     "prod:ps": "docker compose --env-file .env.prod -f infra/docker-compose.prod.yml ps",
     "prod:logs": "docker compose --env-file .env.prod -f infra/docker-compose.prod.yml logs -f --tail=100",
     "prod:db:migrate": "docker compose --env-file .env.prod -f infra/docker-compose.prod.yml run --rm --entrypoint sh api -c 'cd /app && alembic upgrade head'",
+    "prod:db:backup": "mkdir -p backups && docker compose --env-file .env.prod -f infra/docker-compose.prod.yml exec -T db pg_dump --format=custom --no-owner --no-acl -U postgres vacation_tracker > \"backups/pre-migrate-${DEPLOY_SHA:-$(date -u +%Y%m%dT%H%M%SZ)}.dump\"",
+    "prod:health:ready": "curl -fsS --retry 12 --retry-delay 5 --retry-all-errors http://127.0.0.1:8001/ready",
     "prod:query": "node scripts/prod-query.mjs"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

Pulls proven patterns from the sibling **showbook** repo into VPT (web-only, Python/FastAPI + Alembic), skipping the parts that don't translate (mobile/Expo/Maestro, Drizzle, the e2e backend stack).

- **infra/docker-compose.prod.yml** — explicit `container_name: vpt-prod-<svc>` on every service (no more `…-1` suffix, matching showbook's `showbook-prod-<svc>`); `stop_grace_period: 30s` on web.
- **deploy.yml** — **pre-migration DB backup** (`pnpm prod:db:backup`, `pg_dump --format=custom` → `backups/pre-migrate-<sha>.dump`) before migrations, and a **post-deploy health gate** (`pnpm prod:health:ready` → `/ready` with retries) after. Mirrors showbook's deploy.
- **api** — guard `create_all` to non-production in the lifespan so **Alembic owns the prod schema**. This fixes the deploy-time `relation "users" already exists` migration race (the app was creating tables on boot, before `prod:db:migrate` ran).
- **docs/** — `SECURITY.md` (private vuln reporting + scope) and `GUARDRAILS.md` (canonical auth gates, admin-SQL defense-in-depth, rate limits, idempotency, provider cost caps, operational guards).
- **skills/** — new `bug-fixing` skill (reproduce + fix, verify locally **without** E2E, then hand to `creating-prs` for the PR/CI loop).
- `.gitignore backups/`.

## Gap analysis (showbook → VPT)

Adopted here: container naming, pre-migration backup, health gate, prod `create_all` guard, SECURITY/GUARDRAILS docs, bug-fixing skill, graceful shutdown.

Deliberately deferred (need your input / follow-up): **auto image rollback** on a failed deploy (showbook re-points to a `:rollback` tag — riskier, touches live prod, and VPT has 3 images vs showbook's 1), and a **nightly `backup-postgres.mjs`** with retention + optional rclone offsite (needs cron + storage decisions). N/A: mobile e2e, Drizzle tooling, the separate e2e backend stack.

## Test plan

- [x] `infra/docker-compose.prod.yml` validates; container names + `stop_grace_period` confirmed via `docker compose config`
- [x] `deploy.yml` parses; `package.json` valid
- [x] api coverage gate holds (95.24%) with the `create_all` guard
- [ ] CI green (nextjs / python / sonarqube)
- [ ] On next deploy: `backups/pre-migrate-<sha>.dump` written, health gate passes, migrations run clean from a stamped base

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CLU2qzji7MCM2UREz8yaZR

---
_Generated by [Claude Code](https://claude.ai/code/session_012iAa5gbXg1jiGBVWgJcnYj)_