### PR TITLE
fix: remove copilot/gemini/cursor instruction symlinks

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -1,1 +1,0 @@
-CLAUDE.md

--- a/.gemini-instructions.md
+++ b/.gemini-instructions.md
@@ -1,1 +1,0 @@
-CLAUDE.md

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,1 +1,0 @@
-../CLAUDE.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,12 +4,9 @@ This file provides guidance to AI coding assistants when working with code in th
 repository. It covers **repo-wide conventions only** — app-specific detail lives in
 per-app guides (see below).
 
-**Supported AI Assistants** (all via symlinks to this single source of truth):
+**Supported AI Assistants** (via a symlink to this single source of truth):
 - Claude Code — `CLAUDE.md`
 - OpenAI/agentic tools — `AGENTS.md` → `CLAUDE.md`
-- GitHub Copilot — `.github/copilot-instructions.md` → `../CLAUDE.md`
-- JetBrains AI Assistant — `.cursorrules` → `CLAUDE.md`
-- Gemini Code Assist — `.gemini-instructions.md` → `CLAUDE.md`
 
 ## Per-App Guides
 


### PR DESCRIPTION
## Summary

Removes the three assistant-instruction symlinks added in #7 and all references to them:
- `.github/copilot-instructions.md` (→ `../CLAUDE.md`)
- `.gemini-instructions.md` (→ `CLAUDE.md`)
- `.cursorrules` (→ `CLAUDE.md`)
- the corresponding bullets in `CLAUDE.md`'s "Supported AI Assistants" list

**Why:** remote Claude Code sessions stopped starting for this repo after #7. `.github/copilot-instructions.md → ../CLAUDE.md` is a symlink that **escapes its own directory**, which sandbox/file-provisioning layers commonly reject as path traversal and abort environment creation. showbook (which starts fine) has none of these symlinks. Everything else checked out (hook can't fail a session, lockfiles in sync, settings.json valid).

`AGENTS.md → CLAUDE.md` is **kept** — it's a same-directory symlink that predates the breakage and worked fine.

## Test plan

- [x] Symlinks removed; `git grep` finds no remaining references in tracked files
- [x] `AGENTS.md` still resolves to `CLAUDE.md`
- [ ] After merge: starting a new remote Claude Code session for this repo succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CLU2qzji7MCM2UREz8yaZR

---
_Generated by [Claude Code](https://claude.ai/code/session_012iAa5gbXg1jiGBVWgJcnYj)_