### PR TITLE
feat(api): add daily quotas and global spend circuit-breaker

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -131,11 +131,12 @@ RATE_LIMIT_PER_MINUTE=100
 CHAT_RATE_LIMIT_PER_MINUTE=10
 
 # Cost / abuse ceilings: per-user daily quotas + a global daily spend
-# circuit-breaker (Redis, auto-reset at UTC midnight). Master on/off switch only;
-# the numeric ceilings (CHAT_DAILY_QUOTA_PER_USER, DAILY_QUOTA_PER_USER,
-# GLOBAL_DAILY_GROQ_TOKEN_BUDGET, GLOBAL_DAILY_SKIPLAGGED_CALL_BUDGET) are
-# env-overridable but documented in apps/api/CLAUDE.md rather than listed here.
-ENABLE_COST_CEILINGS=true
+# circuit-breaker (Redis, auto-reset at UTC midnight). Always on — these four
+# limits are the only knobs; set one very high to effectively disable it.
+CHAT_DAILY_QUOTA_PER_USER=200            # message-producing chat requests/user/day
+DAILY_QUOTA_PER_USER=2000               # overall API requests/user/day
+GLOBAL_DAILY_GROQ_TOKEN_BUDGET=50000000  # Groq tokens/day across all users
+GLOBAL_DAILY_SKIPLAGGED_CALL_BUDGET=50000  # Skiplagged MCP calls/day across all users
 
 # =============================================================================
 # CACHING (Redis)

--- a/.env.example
+++ b/.env.example
@@ -130,6 +130,13 @@ RATE_LIMIT_PER_MINUTE=100
 # Max chat messages per minute per user (LLM calls are expensive)
 CHAT_RATE_LIMIT_PER_MINUTE=10
 
+# Cost / abuse ceilings: per-user daily quotas + a global daily spend
+# circuit-breaker (Redis, auto-reset at UTC midnight). Master on/off switch only;
+# the numeric ceilings (CHAT_DAILY_QUOTA_PER_USER, DAILY_QUOTA_PER_USER,
+# GLOBAL_DAILY_GROQ_TOKEN_BUDGET, GLOBAL_DAILY_SKIPLAGGED_CALL_BUDGET) are
+# env-overridable but documented in apps/api/CLAUDE.md rather than listed here.
+ENABLE_COST_CEILINGS=true
+
 # =============================================================================
 # CACHING (Redis)
 # =============================================================================

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,9 +75,14 @@ stack, copy `.env.prod.example` to `.env.prod` (see Deployment).
 `LANGFUSE_*` (LLM/MCP tracing).
 
 **Feature flags:** `ENABLE_BETA_OPTIMIZER`, `ENABLE_SMS_NOTIFICATIONS`,
-`MAX_TRIPS_PER_USER` (default 10), `ENABLE_COST_CEILINGS` (per-user daily quotas
-+ a global daily Groq/Skiplagged spend circuit-breaker in Redis, auto-resetting
-at UTC midnight; details in [`apps/api/CLAUDE.md`](apps/api/CLAUDE.md)).
+`MAX_TRIPS_PER_USER` (default 10).
+
+**Cost / abuse ceilings** are always on (like the per-minute rate limiter):
+per-user daily quotas + a global daily Groq/Skiplagged spend circuit-breaker in
+Redis, auto-resetting at UTC midnight. Tune via `CHAT_DAILY_QUOTA_PER_USER`,
+`DAILY_QUOTA_PER_USER`, `GLOBAL_DAILY_GROQ_TOKEN_BUDGET`,
+`GLOBAL_DAILY_SKIPLAGGED_CALL_BUDGET` (details in
+[`apps/api/CLAUDE.md`](apps/api/CLAUDE.md)).
 
 ## Directory Structure
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,7 +75,9 @@ stack, copy `.env.prod.example` to `.env.prod` (see Deployment).
 `LANGFUSE_*` (LLM/MCP tracing).
 
 **Feature flags:** `ENABLE_BETA_OPTIMIZER`, `ENABLE_SMS_NOTIFICATIONS`,
-`MAX_TRIPS_PER_USER` (default 10).
+`MAX_TRIPS_PER_USER` (default 10), `ENABLE_COST_CEILINGS` (per-user daily quotas
++ a global daily Groq/Skiplagged spend circuit-breaker in Redis, auto-resetting
+at UTC midnight; details in [`apps/api/CLAUDE.md`](apps/api/CLAUDE.md)).
 
 ## Directory Structure
 

--- a/apps/api/CLAUDE.md
+++ b/apps/api/CLAUDE.md
@@ -82,7 +82,8 @@ On top of the per-minute limiter, two Redis-backed daily defenses guard against
 unbounded spend (a user parked at the per-minute cap for hours, or a leaked
 session). All counters carry a `:{YYYYMMDD}` (UTC) suffix and a
 seconds-to-midnight TTL, so they **auto-reset at UTC midnight — no cron**. Every
-helper **fails open** on a Redis error. Master switch: `ENABLE_COST_CEILINGS`.
+helper **fails open** on a Redis error. Always on (like the per-minute limiter);
+there is no on/off flag — set a limit very high to effectively disable it.
 
 - **Per-user daily quota** — day-bucketed counters enforced in
   `rate_limit_middleware`: an overall API cap (`DAILY_QUOTA_PER_USER`, default
@@ -109,8 +110,8 @@ helper **fails open** on a Redis error. Master switch: `ENABLE_COST_CEILINGS`.
   global breaker simultaneously. Defense-in-depth (process-local fallback, or a
   hard provider-side spend cap) is intentionally out of scope.
 
-The four numeric ceilings are plain env-overridable `Settings` fields; only
-`ENABLE_COST_CEILINGS` is surfaced in `.env.example`.
+The four numeric ceilings are plain env-overridable `Settings` fields, all
+surfaced in `.env.example` (they're the only knobs).
 
 ## Skiplagged MCP client
 

--- a/apps/api/CLAUDE.md
+++ b/apps/api/CLAUDE.md
@@ -76,6 +76,42 @@ the SQLite test DB.
 - Per-user token-bucket throttling so no single user can hammer Skiplagged MCP.
 - `rate_limit_per_minute` (default 100) and `chat_rate_limit_per_minute` (default 10).
 
+### Cost / abuse ceilings (`app/core/quota.py`)
+
+On top of the per-minute limiter, two Redis-backed daily defenses guard against
+unbounded spend (a user parked at the per-minute cap for hours, or a leaked
+session). All counters carry a `:{YYYYMMDD}` (UTC) suffix and a
+seconds-to-midnight TTL, so they **auto-reset at UTC midnight — no cron**. Every
+helper **fails open** on a Redis error. Master switch: `ENABLE_COST_CEILINGS`.
+
+- **Per-user daily quota** — day-bucketed counters enforced in
+  `rate_limit_middleware`: an overall API cap (`DAILY_QUOTA_PER_USER`, default
+  2000) and a stricter cap on message-producing chat (`/v1/chat/messages`,
+  `/v1/chat/elicitation`) via `CHAT_DAILY_QUOTA_PER_USER` (default 200). Over
+  limit → 429 with `Retry-After` = seconds to midnight. Keys:
+  `daily_quota:{identifier}:{resource}:{day}`.
+- **Global daily budget guard / circuit breaker** — a per-UTC-day counter per
+  metric, incremented at the two shared provider chokepoints so the worker's
+  scheduled refreshes are covered too:
+  - `groq.chat()` adds `total_tokens` after each completion
+    (`GLOBAL_DAILY_GROQ_TOKEN_BUDGET`, default 50,000,000). Requires
+    `stream_options={"include_usage": True}` on streaming calls.
+  - `skiplagged._call_mcp()` adds 1 per MCP call
+    (`GLOBAL_DAILY_SKIPLAGGED_CALL_BUDGET`, default 50,000).
+  When a metric's day total crosses its ceiling the breaker trips: the chat
+  middleware / manual-refresh trigger reject new work (503 `GlobalBudgetExceeded`)
+  and the provider clients raise `GlobalBudgetExceeded` so in-flight chat (SSE
+  error chunk) and worker activities (non-retriable Temporal error) fail
+  gracefully. Keys: `global_budget:{metric}:{day}`. The trip is logged at WARNING
+  (stdout — there is no Axiom).
+- **Residual risk:** all three limiters are Redis-backed and fail open, so a
+  Redis outage disables the per-minute limiter, the per-user daily quota, and the
+  global breaker simultaneously. Defense-in-depth (process-local fallback, or a
+  hard provider-side spend cap) is intentionally out of scope.
+
+The four numeric ceilings are plain env-overridable `Settings` fields; only
+`ENABLE_COST_CEILINGS` is surfaced in `.env.example`.
+
 ## Skiplagged MCP client
 
 `app/clients/skiplagged.py` speaks JSON-RPC 2.0 over Streamable HTTP to

--- a/apps/api/app/clients/groq.py
+++ b/apps/api/app/clients/groq.py
@@ -12,6 +12,8 @@ import tiktoken
 from groq import APIError, AsyncGroq, RateLimitError
 
 from app.core.config import settings
+from app.core.errors import GlobalBudgetExceeded
+from app.core.quota import incr_and_check_global_budget, is_global_budget_tripped
 from app.core.telemetry import langfuse_context, observe
 
 if TYPE_CHECKING:
@@ -286,6 +288,10 @@ class GroqClient:
             "temperature": temperature,
             "stream": stream,
         }
+        if stream:
+            # Without this the streaming API emits no terminal usage chunk, so
+            # token accounting (Langfuse + the global Groq budget) sees nothing.
+            kwargs["stream_options"] = {"include_usage": True}
         if tools:
             kwargs["tools"] = [tool.to_dict() for tool in tools]
         if max_tokens:
@@ -451,6 +457,11 @@ class GroqClient:
             GroqRateLimitError: If rate limited after all retries.
             GroqRequestError: If the request fails.
         """
+        # Global daily spend breaker: reject before spending if a prior call has
+        # already pushed the day over budget. The crossing call is allowed to
+        # finish; this gates the next one (e.g. the next tool round / request).
+        await self._enforce_global_budget()
+
         self._record_generation_input(messages, tools, stream, temperature, max_tokens)
         client = self._get_client()
         kwargs = self._build_chat_kwargs(messages, tools, stream, temperature, max_tokens)
@@ -464,6 +475,7 @@ class GroqClient:
                     self._accumulate_for_trace(chunk, accumulator)
                     yield chunk
                 self._record_generation_output(accumulator)
+                await self._meter_token_usage(accumulator)
                 return
             except RateLimitError as e:
                 delay, chunk = await self._handle_rate_limit_in_chat(e, attempt, max_attempts)
@@ -478,6 +490,32 @@ class GroqClient:
             except Exception as e:
                 logger.exception("Groq API request failed")
                 raise GroqRequestError(f"Groq request failed: {e}") from e
+
+    @staticmethod
+    async def _enforce_global_budget() -> None:
+        """Raise GlobalBudgetExceeded if the daily Groq token budget is tripped."""
+        if not settings.enable_cost_ceilings:
+            return
+        if await is_global_budget_tripped(
+            "groq_tokens", settings.global_daily_groq_token_budget
+        ):
+            raise GlobalBudgetExceeded(
+                "The AI service has reached its daily usage ceiling. Please try again tomorrow."
+            )
+
+    @staticmethod
+    async def _meter_token_usage(accumulator: dict[str, Any]) -> None:
+        """Add this completion's token usage to the global daily Groq budget."""
+        if not settings.enable_cost_ceilings:
+            return
+        usage = accumulator.get("usage")
+        if not usage or not usage.get("total_tokens"):
+            return
+        await incr_and_check_global_budget(
+            "groq_tokens",
+            int(usage["total_tokens"]),
+            settings.global_daily_groq_token_budget,
+        )
 
     def _record_generation_input(
         self,

--- a/apps/api/app/clients/groq.py
+++ b/apps/api/app/clients/groq.py
@@ -494,8 +494,6 @@ class GroqClient:
     @staticmethod
     async def _enforce_global_budget() -> None:
         """Raise GlobalBudgetExceeded if the daily Groq token budget is tripped."""
-        if not settings.enable_cost_ceilings:
-            return
         if await is_global_budget_tripped(
             "groq_tokens", settings.global_daily_groq_token_budget
         ):
@@ -506,8 +504,6 @@ class GroqClient:
     @staticmethod
     async def _meter_token_usage(accumulator: dict[str, Any]) -> None:
         """Add this completion's token usage to the global daily Groq budget."""
-        if not settings.enable_cost_ceilings:
-            return
         usage = accumulator.get("usage")
         if not usage or not usage.get("total_tokens"):
             return

--- a/apps/api/app/clients/skiplagged.py
+++ b/apps/api/app/clients/skiplagged.py
@@ -17,6 +17,9 @@ from typing import Any
 import httpx
 
 from app.clients.skiplagged_parser import parse_flight_segments
+from app.core.config import settings
+from app.core.errors import GlobalBudgetExceeded
+from app.core.quota import incr_and_check_global_budget
 from app.core.telemetry import langfuse_context, observe
 from app.schemas.flight_search import FlightSearchFlight, FlightSearchResult
 from app.schemas.hotel_search import HotelRoom, HotelSearchHotel, HotelSearchResult
@@ -141,6 +144,25 @@ class SkiplaggedClient:
         self._initialized = True
         logger.debug("Skiplagged MCP session initialized: session_id=%s", self._session_id)
 
+    @staticmethod
+    async def _enforce_global_budget() -> None:
+        """Meter this MCP call against the global daily Skiplagged call budget.
+
+        One increment per logical `_call_mcp` (the internal transient-retry loop is
+        not separately counted). Raises GlobalBudgetExceeded once the day's total
+        crosses the ceiling so the worker activity / chat tool fails gracefully.
+        """
+        if not settings.enable_cost_ceilings:
+            return
+        within, _ = await incr_and_check_global_budget(
+            "skiplagged_calls", 1, settings.global_daily_skiplagged_call_budget
+        )
+        if not within:
+            raise GlobalBudgetExceeded(
+                "The flight/hotel search service has reached its daily ceiling. "
+                "Please try again tomorrow."
+            )
+
     @observe(name="skiplagged.mcp_call")
     async def _call_mcp(self, tool_name: str, params: dict[str, Any]) -> dict[str, Any]:
         """Call the MCP server with JSON-RPC format.
@@ -158,6 +180,7 @@ class SkiplaggedClient:
             metadata={"provider": "skiplagged", "mcp_url": self._mcp_url, "tool_name": tool_name},
         )
         await self._ensure_initialized()
+        await self._enforce_global_budget()
 
         payload = {
             "jsonrpc": "2.0",

--- a/apps/api/app/clients/skiplagged.py
+++ b/apps/api/app/clients/skiplagged.py
@@ -152,8 +152,6 @@ class SkiplaggedClient:
         not separately counted). Raises GlobalBudgetExceeded once the day's total
         crosses the ceiling so the worker activity / chat tool fails gracefully.
         """
-        if not settings.enable_cost_ceilings:
-            return
         within, _ = await incr_and_check_global_budget(
             "skiplagged_calls", 1, settings.global_daily_skiplagged_call_budget
         )

--- a/apps/api/app/core/cache_keys.py
+++ b/apps/api/app/core/cache_keys.py
@@ -53,6 +53,17 @@ class CacheKeys:
         """Key for rate limit tracking (e.g., resource='api', 'price_check')."""
         return f"rate_limit:{user_id}:{resource}"
 
+    # Cost / abuse ceilings (per-user daily quota + global daily budget guard)
+    @staticmethod
+    def daily_quota(identifier: str, resource: str, day: str) -> str:
+        """Per-user daily quota counter. day=YYYYMMDD (UTC); auto-expires at midnight."""
+        return f"daily_quota:{identifier}:{resource}:{day}"
+
+    @staticmethod
+    def global_budget(metric: str, day: str) -> str:
+        """Global per-UTC-day spend counter. metric in {'groq_tokens', 'skiplagged_calls'}."""
+        return f"global_budget:{metric}:{day}"
+
 
 class CacheTTL:
     """Centralized TTL constants (in seconds)."""
@@ -64,3 +75,4 @@ class CacheTTL:
     RATE_LIMIT = 60  # 1 minute window (for per-minute rate limiting)
     REFRESH_LOCK = 1800  # 30 minutes
     AUDIT_LOG_RETENTION = 86400 * 90  # 90 days
+    DAILY_QUOTA_MIN_TTL = 60  # floor for the seconds-to-midnight day-bucket TTL

--- a/apps/api/app/core/config.py
+++ b/apps/api/app/core/config.py
@@ -76,10 +76,9 @@ class Settings(BaseSettings):
     chat_rate_limit_per_minute: int = 10
 
     # Cost / abuse ceilings (daily quotas + global daily spend circuit-breaker).
-    # All counters live in Redis and auto-reset at UTC midnight. Every field is
-    # env-overridable; only ENABLE_COST_CEILINGS is surfaced in .env.example —
-    # the numeric ceilings are documented in apps/api/CLAUDE.md.
-    enable_cost_ceilings: bool = True  # master kill-switch for the whole feature
+    # Always on, like the per-minute rate limiter above. All counters live in
+    # Redis and auto-reset at UTC midnight. The four limits are the tunable knobs
+    # (surfaced in .env.example); set one very high to effectively disable it.
     chat_daily_quota_per_user: int = 200  # message-producing chat requests/user/day
     daily_quota_per_user: int = 2000  # overall API requests/user/day
     global_daily_groq_token_budget: int = 50_000_000  # Groq tokens/day across all users

--- a/apps/api/app/core/config.py
+++ b/apps/api/app/core/config.py
@@ -75,6 +75,16 @@ class Settings(BaseSettings):
     rate_limit_per_minute: int = 100
     chat_rate_limit_per_minute: int = 10
 
+    # Cost / abuse ceilings (daily quotas + global daily spend circuit-breaker).
+    # All counters live in Redis and auto-reset at UTC midnight. Every field is
+    # env-overridable; only ENABLE_COST_CEILINGS is surfaced in .env.example —
+    # the numeric ceilings are documented in apps/api/CLAUDE.md.
+    enable_cost_ceilings: bool = True  # master kill-switch for the whole feature
+    chat_daily_quota_per_user: int = 200  # message-producing chat requests/user/day
+    daily_quota_per_user: int = 2000  # overall API requests/user/day
+    global_daily_groq_token_budget: int = 50_000_000  # Groq tokens/day across all users
+    global_daily_skiplagged_call_budget: int = 50_000  # Skiplagged MCP calls/day, all users
+
     # Observability
     otel_exporter_otlp_endpoint: str = "http://localhost:4317"
     log_level: str = "INFO"

--- a/apps/api/app/core/errors.py
+++ b/apps/api/app/core/errors.py
@@ -196,9 +196,39 @@ class RateLimitExceeded(AppError):
         return payload
 
 
+class GlobalBudgetExceeded(ServiceUnavailableError):
+    """Raised when the global daily spend ceiling (circuit breaker) has tripped.
+
+    Distinct from RateLimitExceeded (a per-user quota): this means the service as
+    a whole has hit its aggregate daily cost ceiling and is shedding load until
+    the counter resets at UTC midnight.
+    """
+
+    type = problem_type("global-budget-exceeded")
+    detail = "Service temporarily unavailable due to daily cost ceiling. Try again later."
+
+    def __init__(
+        self,
+        detail: str | None = None,
+        *,
+        retry_after: int | None = None,
+        extra: dict[str, Any] | None = None,
+    ) -> None:
+        super().__init__(detail, extra=extra)
+        self.retry_after = retry_after
+
+    def to_problem_detail(self, instance: str | None = None) -> dict[str, Any]:
+        payload = super().to_problem_detail(instance)
+        if self.retry_after is not None:
+            payload["retry_after"] = self.retry_after
+        return payload
+
+
 def problem_details_response(exc: AppError, request: Request) -> JSONResponse:
     headers = {}
     if isinstance(exc, RateLimitExceeded):
+        headers["Retry-After"] = str(exc.retry_after)
+    elif isinstance(exc, GlobalBudgetExceeded) and exc.retry_after is not None:
         headers["Retry-After"] = str(exc.retry_after)
     return JSONResponse(
         status_code=exc.status_code,

--- a/apps/api/app/core/quota.py
+++ b/apps/api/app/core/quota.py
@@ -1,0 +1,194 @@
+"""Cost / abuse ceilings: per-user daily quotas + a global daily budget guard.
+
+These are Redis-backed defenses layered on top of the per-minute rate limiter
+(`app/middleware/rate_limit.py`):
+
+- **Per-user daily quota** (`check_and_incr_daily_quota`) — a day-bucketed
+  counter, atomically checked + incremented, mirroring the per-minute limiter.
+- **Global daily budget guard / circuit breaker** (`incr_and_check_global_budget`
+  + `is_global_budget_tripped`) — a per-UTC-day counter incremented at the shared
+  provider chokepoints (`groq.chat()`, `skiplagged._call_mcp()`) so a leaked
+  session or aggregate abuse can't run up an unbounded bill silently.
+
+All keys carry a `:{YYYYMMDD}` (UTC) suffix and a seconds-to-midnight TTL, so the
+quotas and the breaker auto-reset at UTC midnight — no cleanup job. Every helper
+**fails open** on Redis error (logs a warning, allows the request); the per-user
+quota and per-minute limiter remain the backstop.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime, timedelta
+
+from app.core.cache_keys import CacheKeys, CacheTTL
+from app.db.redis import redis_client
+
+logger = logging.getLogger(__name__)
+
+
+def _now(now: datetime | None) -> datetime:
+    return now or datetime.now(UTC)
+
+
+def _day_bucket(now: datetime) -> str:
+    """UTC calendar-day bucket, e.g. '20260623'."""
+    return now.astimezone(UTC).strftime("%Y%m%d")
+
+
+def _seconds_to_utc_midnight(now: datetime | None = None) -> int:
+    """Seconds from `now` until the next 00:00 UTC.
+
+    Used as the TTL for every day-bucket key so they all expire together at the
+    reset boundary. Floored at `CacheTTL.DAILY_QUOTA_MIN_TTL` so a request landing
+    a second before midnight still sets a usable TTL.
+    """
+    current = _now(now).astimezone(UTC)
+    next_midnight = (current + timedelta(days=1)).replace(
+        hour=0, minute=0, second=0, microsecond=0
+    )
+    return max(CacheTTL.DAILY_QUOTA_MIN_TTL, int((next_midnight - current).total_seconds()))
+
+
+# GET → compare to limit → INCR → repair TTL when missing. Returns
+# [allowed, remaining, retry_after]. Mirrors the per-minute limiter's script but
+# with a seconds-to-midnight TTL and an unconditional EXPIRE whenever the key has
+# no TTL (a dropped EXPIRE on a day-bucket key would otherwise never self-heal).
+_DAILY_QUOTA_LUA = """
+local key = KEYS[1]
+local max_requests = tonumber(ARGV[1])
+local ttl = tonumber(ARGV[2])
+
+local current = redis.call('GET', key)
+if current == false then
+    current = 0
+else
+    current = tonumber(current)
+end
+
+if current >= max_requests then
+    local remaining_ttl = redis.call('TTL', key)
+    if remaining_ttl < 0 then
+        redis.call('EXPIRE', key, ttl)
+        remaining_ttl = ttl
+    end
+    return {0, 0, remaining_ttl}
+end
+
+local new_count = redis.call('INCR', key)
+if redis.call('TTL', key) < 0 then
+    redis.call('EXPIRE', key, ttl)
+end
+
+local remaining = max_requests - new_count
+if remaining < 0 then
+    remaining = 0
+end
+return {1, remaining, 0}
+"""
+
+
+# INCRBY → repair TTL when missing → compare to limit. Returns [within, total].
+_GLOBAL_BUDGET_LUA = """
+local key = KEYS[1]
+local amount = tonumber(ARGV[1])
+local limit = tonumber(ARGV[2])
+local ttl = tonumber(ARGV[3])
+
+local total = redis.call('INCRBY', key, amount)
+if redis.call('TTL', key) < 0 then
+    redis.call('EXPIRE', key, ttl)
+end
+
+if total <= limit then
+    return {1, total}
+end
+return {0, total}
+"""
+
+
+async def check_and_incr_daily_quota(
+    identifier: str,
+    resource: str,
+    limit: int,
+    *,
+    now: datetime | None = None,
+) -> tuple[bool, int, int]:
+    """Atomically check + increment a per-day counter for (identifier, resource).
+
+    Returns ``(allowed, remaining, retry_after_seconds)``. When over limit,
+    ``(False, 0, seconds_to_midnight)``. Fails open as ``(True, limit, 0)`` on a
+    Redis error.
+    """
+    moment = _now(now)
+    key = CacheKeys.daily_quota(identifier, resource, _day_bucket(moment))
+    ttl = _seconds_to_utc_midnight(moment)
+    try:
+        allowed, remaining, retry_after = await redis_client.eval(
+            _DAILY_QUOTA_LUA, 1, key, str(limit), str(ttl)
+        )
+        return bool(allowed), int(remaining), int(retry_after)
+    except Exception as exc:  # pragma: no cover - exercised via monkeypatched eval
+        logger.warning("Daily quota check failed, allowing request: %s", exc)
+        return True, limit, 0
+
+
+async def incr_and_check_global_budget(
+    metric: str,
+    amount: int,
+    limit: int,
+    *,
+    now: datetime | None = None,
+) -> tuple[bool, int]:
+    """Atomically add ``amount`` to the global per-UTC-day counter for ``metric``.
+
+    Returns ``(within_budget, total_after_increment)``. Fails open as
+    ``(True, 0)`` on a Redis error. Logs a warning on the increment that trips the
+    breaker so the operator has a signal in stdout (there is no Axiom).
+    """
+    moment = _now(now)
+    key = CacheKeys.global_budget(metric, _day_bucket(moment))
+    ttl = _seconds_to_utc_midnight(moment)
+    try:
+        within, total = await redis_client.eval(
+            _GLOBAL_BUDGET_LUA, 1, key, str(amount), str(limit), str(ttl)
+        )
+    except Exception as exc:  # pragma: no cover - exercised via monkeypatched eval
+        logger.warning("Global budget increment failed, allowing request: %s", exc)
+        return True, 0
+
+    within, total = bool(within), int(total)
+    if not within and (total - amount) <= limit:
+        # Log only on the increment that crosses the line, not every call after.
+        logger.warning(
+            "Global budget breaker tripped: metric=%s total=%s limit=%s",
+            metric,
+            total,
+            limit,
+        )
+    return within, total
+
+
+async def is_global_budget_tripped(
+    metric: str,
+    limit: int,
+    *,
+    now: datetime | None = None,
+) -> bool:
+    """Read-only check (no increment) of whether the breaker is tripped.
+
+    Used by edge gatekeepers (chat middleware, manual-refresh trigger) to reject
+    new expensive work cheaply. Fails open as ``False`` (not tripped) on error.
+    """
+    key = CacheKeys.global_budget(metric, _day_bucket(_now(now)))
+    try:
+        raw = await redis_client.get(key)
+    except Exception as exc:  # pragma: no cover - exercised via monkeypatched get
+        logger.warning("Global budget read failed, treating as not tripped: %s", exc)
+        return False
+    if raw is None:
+        return False
+    try:
+        return int(raw) > limit
+    except (TypeError, ValueError):
+        return False

--- a/apps/api/app/middleware/rate_limit.py
+++ b/apps/api/app/middleware/rate_limit.py
@@ -210,12 +210,9 @@ async def _check_daily_ceilings(request: Request, identifier: str) -> Response |
     """Enforce per-user daily quotas + the global budget breaker at the edge.
 
     Returns a rejection Response when a ceiling is hit, or None to proceed.
-    Skipped entirely when cost ceilings are disabled. Fails open (returns None)
-    on Redis errors via the underlying quota helpers.
+    Always on (like the per-minute limiter); fails open (returns None) on Redis
+    errors via the underlying quota helpers.
     """
-    if not settings.enable_cost_ceilings:
-        return None
-
     path = request.url.path
     is_chat_message = _is_chat_message_path(path)
     is_refresh = _is_refresh_trigger(request)

--- a/apps/api/app/middleware/rate_limit.py
+++ b/apps/api/app/middleware/rate_limit.py
@@ -12,7 +12,12 @@ from fastapi.responses import JSONResponse, Response
 from app.core.cache_keys import CacheKeys, CacheTTL
 from app.core.config import settings
 from app.core.constants import CookieNames, JWTClaims
-from app.core.errors import PROBLEM_JSON_MEDIA_TYPE, RateLimitExceeded
+from app.core.errors import PROBLEM_JSON_MEDIA_TYPE, GlobalBudgetExceeded, RateLimitExceeded
+from app.core.quota import (
+    _seconds_to_utc_midnight,
+    check_and_incr_daily_quota,
+    is_global_budget_tripped,
+)
 from app.db.redis import redis_client
 
 logger = logging.getLogger(__name__)
@@ -22,6 +27,11 @@ EXEMPT_PATHS = {"/health", "/ready", "/docs", "/redoc", "/openapi.json", "/v1/ss
 
 # Chat endpoints have stricter rate limits (10/min per user)
 CHAT_PATHS = {"/v1/chat/messages", "/v1/chat"}
+
+# Message-producing chat endpoints that actually drive Groq calls. The daily chat
+# quota counts only these (not conversation list/read/delete under /v1/chat),
+# unlike the per-minute limiter which gates the whole /v1/chat prefix.
+CHAT_MESSAGE_PATHS = {"/v1/chat/messages", "/v1/chat/elicitation"}
 
 
 def _get_client_ip(request: Request) -> str:
@@ -73,6 +83,25 @@ def _get_rate_limit_identifier(request: Request) -> str:
 def _is_chat_path(path: str) -> bool:
     """Check if the request path is a chat endpoint."""
     return any(path.startswith(chat_path) for chat_path in CHAT_PATHS)
+
+
+def _is_chat_message_path(path: str) -> bool:
+    """Check if the path is a message-producing chat endpoint (drives Groq)."""
+    return path in CHAT_MESSAGE_PATHS
+
+
+def _is_refresh_trigger(request: Request) -> bool:
+    """Check if the request triggers a (Skiplagged-backed) price refresh.
+
+    Matches POST /v1/trips/refresh-all and POST /v1/trips/{trip_id}/refresh
+    without catching GET /v1/trips/refresh-status.
+    """
+    if request.method != "POST":
+        return False
+    path = request.url.path
+    return path == "/v1/trips/refresh-all" or (
+        path.startswith("/v1/trips/") and path.endswith("/refresh")
+    )
 
 
 async def _check_rate_limit(
@@ -166,6 +195,63 @@ def _rate_limit_response(retry_after: int, path: str) -> Response:
     )
 
 
+def _budget_response(retry_after: int, path: str) -> Response:
+    """Create a 503 response when the global daily budget breaker is tripped."""
+    exc = GlobalBudgetExceeded(retry_after=retry_after)
+    return JSONResponse(
+        status_code=exc.status_code,
+        content=exc.to_problem_detail(path),
+        media_type=PROBLEM_JSON_MEDIA_TYPE,
+        headers={"Retry-After": str(retry_after)},
+    )
+
+
+async def _check_daily_ceilings(request: Request, identifier: str) -> Response | None:
+    """Enforce per-user daily quotas + the global budget breaker at the edge.
+
+    Returns a rejection Response when a ceiling is hit, or None to proceed.
+    Skipped entirely when cost ceilings are disabled. Fails open (returns None)
+    on Redis errors via the underlying quota helpers.
+    """
+    if not settings.enable_cost_ceilings:
+        return None
+
+    path = request.url.path
+    is_chat_message = _is_chat_message_path(path)
+    is_refresh = _is_refresh_trigger(request)
+
+    # Per-user daily quota: an overall API cap plus a stricter chat-message cap.
+    allowed, _, retry_after = await check_and_incr_daily_quota(
+        identifier, "api", settings.daily_quota_per_user
+    )
+    if not allowed:
+        logger.info("Daily API quota exceeded for %s on path %s", identifier, path)
+        return _rate_limit_response(retry_after, path)
+
+    if is_chat_message:
+        allowed, _, retry_after = await check_and_incr_daily_quota(
+            identifier, "chat", settings.chat_daily_quota_per_user
+        )
+        if not allowed:
+            logger.info("Daily chat quota exceeded for %s on path %s", identifier, path)
+            return _rate_limit_response(retry_after, path)
+
+    # Global budget breaker (read-only gate): reject new expensive work cheaply.
+    if is_chat_message and await is_global_budget_tripped(
+        "groq_tokens", settings.global_daily_groq_token_budget
+    ):
+        logger.warning("Global Groq budget tripped; rejecting chat on %s", path)
+        return _budget_response(_seconds_to_utc_midnight(), path)
+
+    if is_refresh and await is_global_budget_tripped(
+        "skiplagged_calls", settings.global_daily_skiplagged_call_budget
+    ):
+        logger.warning("Global Skiplagged budget tripped; rejecting refresh on %s", path)
+        return _budget_response(_seconds_to_utc_midnight(), path)
+
+    return None
+
+
 async def rate_limit_middleware(request: Request, call_next) -> Response:
     """Rate limiting middleware using sliding window counter."""
     # Skip rate limiting for exempt paths
@@ -189,6 +275,11 @@ async def rate_limit_middleware(request: Request, call_next) -> Response:
             is_chat,
         )
         return _rate_limit_response(retry_after, request.url.path)
+
+    # Daily quotas + global budget breaker (no-op when ceilings are disabled).
+    ceiling_response = await _check_daily_ceilings(request, identifier)
+    if ceiling_response is not None:
+        return ceiling_response
 
     # Process request
     response = await call_next(request)

--- a/apps/api/app/services/chat.py
+++ b/apps/api/app/services/chat.py
@@ -29,6 +29,7 @@ from app.clients.groq import (
 from app.clients.groq import (
     Message as GroqMessage,
 )
+from app.core.errors import GlobalBudgetExceeded
 from app.core.prompts import build_system_prompt
 from app.core.telemetry import langfuse_context, observe
 from app.models.message import Message
@@ -524,6 +525,10 @@ async def process_chat_with_tools(
                     logger.warning("Tools that hit retry limit: %s", exceeded)
                 return
 
+        except GlobalBudgetExceeded as e:
+            logger.warning("Global budget breaker tripped during chat: %s", e)
+            yield ChatChunk.error_chunk(str(e.detail))
+            return
         except GroqClientError as e:
             _log_groq_error(e)
             yield _get_error_chunk(e)

--- a/apps/api/tests/clients/test_skiplagged.py
+++ b/apps/api/tests/clients/test_skiplagged.py
@@ -745,8 +745,6 @@ class TestSkiplaggedGlobalBudget:
     async def test_call_mcp_increments_budget_and_proceeds(self, monkeypatch):
         import app.clients.skiplagged as sk_module
 
-        monkeypatch.setattr(sk_module.settings, "enable_cost_ceilings", True)
-
         recorded = {}
 
         async def fake_incr(metric, amount, limit, **kwargs):
@@ -773,8 +771,6 @@ class TestSkiplaggedGlobalBudget:
         import app.clients.skiplagged as sk_module
         from app.core.errors import GlobalBudgetExceeded
 
-        monkeypatch.setattr(sk_module.settings, "enable_cost_ceilings", True)
-
         async def over_budget(metric, amount, limit, **kwargs):
             return False, limit + amount
 
@@ -791,29 +787,3 @@ class TestSkiplaggedGlobalBudget:
             await client._call_mcp("sk_flights_search", {"origin": "SFO"})
 
         send.assert_not_called()
-
-    @pytest.mark.anyio
-    async def test_call_mcp_skips_budget_when_disabled(self, monkeypatch):
-        import app.clients.skiplagged as sk_module
-
-        monkeypatch.setattr(sk_module.settings, "enable_cost_ceilings", False)
-
-        called = False
-
-        async def fake_incr(*args, **kwargs):
-            nonlocal called
-            called = True
-            return True, 0
-
-        monkeypatch.setattr(sk_module, "incr_and_check_global_budget", fake_incr)
-
-        client = SkiplaggedClient()
-        client._initialized = True
-        client._session_id = "test-session"
-        mock_post = AsyncMock(return_value=_flights_response(1))
-        with patch("app.clients.skiplagged.httpx.AsyncClient") as MockClient:
-            MockClient.return_value.__aenter__ = AsyncMock(return_value=MagicMock(post=mock_post))
-            MockClient.return_value.__aexit__ = AsyncMock(return_value=False)
-            await client.search_flights("SFO", "CDG", "2026-06-15")
-
-        assert called is False

--- a/apps/api/tests/clients/test_skiplagged.py
+++ b/apps/api/tests/clients/test_skiplagged.py
@@ -738,3 +738,82 @@ class TestSkiplaggedSseParsing:
         # The valid JSON in content[1].text was returned, so we get an empty (but successful) result
         assert result.success is True
         assert result.flights == []
+
+
+class TestSkiplaggedGlobalBudget:
+    @pytest.mark.anyio
+    async def test_call_mcp_increments_budget_and_proceeds(self, monkeypatch):
+        import app.clients.skiplagged as sk_module
+
+        monkeypatch.setattr(sk_module.settings, "enable_cost_ceilings", True)
+
+        recorded = {}
+
+        async def fake_incr(metric, amount, limit, **kwargs):
+            recorded["metric"] = metric
+            recorded["amount"] = amount
+            return True, amount
+
+        monkeypatch.setattr(sk_module, "incr_and_check_global_budget", fake_incr)
+
+        client = SkiplaggedClient()
+        client._initialized = True
+        client._session_id = "test-session"
+        mock_post = AsyncMock(return_value=_flights_response(1))
+        with patch("app.clients.skiplagged.httpx.AsyncClient") as MockClient:
+            MockClient.return_value.__aenter__ = AsyncMock(return_value=MagicMock(post=mock_post))
+            MockClient.return_value.__aexit__ = AsyncMock(return_value=False)
+            result = await client.search_flights("SFO", "CDG", "2026-06-15")
+
+        assert result.success is True
+        assert recorded == {"metric": "skiplagged_calls", "amount": 1}
+
+    @pytest.mark.anyio
+    async def test_call_mcp_raises_when_over_budget_before_sending(self, monkeypatch):
+        import app.clients.skiplagged as sk_module
+        from app.core.errors import GlobalBudgetExceeded
+
+        monkeypatch.setattr(sk_module.settings, "enable_cost_ceilings", True)
+
+        async def over_budget(metric, amount, limit, **kwargs):
+            return False, limit + amount
+
+        monkeypatch.setattr(sk_module, "incr_and_check_global_budget", over_budget)
+
+        client = SkiplaggedClient()
+        client._initialized = True
+        client._session_id = "test-session"
+
+        send = AsyncMock()
+        monkeypatch.setattr(client, "_send_request", send)
+
+        with pytest.raises(GlobalBudgetExceeded):
+            await client._call_mcp("sk_flights_search", {"origin": "SFO"})
+
+        send.assert_not_called()
+
+    @pytest.mark.anyio
+    async def test_call_mcp_skips_budget_when_disabled(self, monkeypatch):
+        import app.clients.skiplagged as sk_module
+
+        monkeypatch.setattr(sk_module.settings, "enable_cost_ceilings", False)
+
+        called = False
+
+        async def fake_incr(*args, **kwargs):
+            nonlocal called
+            called = True
+            return True, 0
+
+        monkeypatch.setattr(sk_module, "incr_and_check_global_budget", fake_incr)
+
+        client = SkiplaggedClient()
+        client._initialized = True
+        client._session_id = "test-session"
+        mock_post = AsyncMock(return_value=_flights_response(1))
+        with patch("app.clients.skiplagged.httpx.AsyncClient") as MockClient:
+            MockClient.return_value.__aenter__ = AsyncMock(return_value=MagicMock(post=mock_post))
+            MockClient.return_value.__aexit__ = AsyncMock(return_value=False)
+            await client.search_flights("SFO", "CDG", "2026-06-15")
+
+        assert called is False

--- a/apps/api/tests/conftest.py
+++ b/apps/api/tests/conftest.py
@@ -88,6 +88,32 @@ async def test_session(test_engine):
         await session.rollback()  # Rollback any uncommitted changes
 
 
+@pytest.fixture(autouse=True)
+def _allow_all_quota_redis():
+    """Default the cost-ceiling quota client to allow-all so unit tests that call
+    the middleware directly (without the `app` fixture) never touch a real Redis.
+
+    Tests that want specific quota/breaker behavior monkeypatch
+    `app.core.quota.redis_client` (or its `.eval`/`.get`) themselves.
+    """
+    import app.core.quota as quota_module
+
+    async def allow_all_eval(script, _numkeys, *args):
+        # The budget Lua INCRBYs and returns [within, total]; the daily-quota Lua
+        # returns [allowed, remaining, retry_after]. Shape the reply to the script.
+        if "INCRBY" in script:
+            return [1, 0]
+        return [1, 1_000_000, 0]
+
+    mock = MagicMock()
+    mock.eval = AsyncMock(side_effect=allow_all_eval)
+    mock.get = AsyncMock(return_value=None)  # global budget: never tripped
+    original = quota_module.redis_client
+    quota_module.redis_client = mock
+    yield
+    quota_module.redis_client = original
+
+
 @pytest.fixture
 def mock_redis():
     """Mock Redis client for testing."""
@@ -122,6 +148,7 @@ def app(test_session, mock_redis, mock_temporal_client):
     fastapi_app.dependency_overrides[get_db] = override_get_db
 
     # Mock redis_client globally
+    import app.core.quota as quota_module
     import app.main as main_module
     import app.middleware.idempotency as idempotency_module
     import app.middleware.rate_limit as rate_limit_module
@@ -130,6 +157,7 @@ def app(test_session, mock_redis, mock_temporal_client):
     auth_module.redis_client = mock_redis
     idempotency_module.redis_client = mock_redis
     rate_limit_module.redis_client = mock_redis
+    quota_module.redis_client = mock_redis
     main_module.redis_client = mock_redis
 
     # Mock temporal_client globally

--- a/apps/api/tests/middleware/test_rate_limit.py
+++ b/apps/api/tests/middleware/test_rate_limit.py
@@ -8,16 +8,20 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from app.core.cache_keys import CacheKeys
+from app.core.config import settings
 from app.core.constants import CookieNames
 from app.core.security import create_access_token
 from app.middleware import rate_limit as rate_limit_module
 from app.middleware.rate_limit import (
     EXEMPT_PATHS,
+    _check_daily_ceilings,
     _check_rate_limit,
     _extract_user_id_from_token,
     _get_client_ip,
     _get_rate_limit_identifier,
+    _is_chat_message_path,
     _is_chat_path,
+    _is_refresh_trigger,
     _rate_limit_response,
     rate_limit_middleware,
 )
@@ -594,3 +598,182 @@ def test_rate_limit_integration_blocked(monkeypatch):
     assert response.headers.get("Retry-After") == "45"
     body = response.json()
     assert body["type"] == "https://vacation-price-tracker.dev/problems/rate-limit-exceeded"
+
+
+# =============================================================================
+# Cost / abuse ceilings: path matchers
+# =============================================================================
+
+
+def test_is_chat_message_path():
+    assert _is_chat_message_path("/v1/chat/messages") is True
+    assert _is_chat_message_path("/v1/chat/elicitation") is True
+    # Non-message chat endpoints are NOT message-producing.
+    assert _is_chat_message_path("/v1/chat/conversations") is False
+    assert _is_chat_message_path("/v1/chat") is False
+
+
+def test_is_refresh_trigger_matches_refresh_all():
+    request = _make_request(method="POST", path="/v1/trips/refresh-all")
+    assert _is_refresh_trigger(request) is True
+
+
+def test_is_refresh_trigger_matches_per_trip_refresh():
+    request = _make_request(method="POST", path="/v1/trips/abc-123/refresh")
+    assert _is_refresh_trigger(request) is True
+
+
+def test_is_refresh_trigger_ignores_refresh_status():
+    # GET refresh-status must not be gated behind the Skiplagged breaker.
+    request = _make_request(method="GET", path="/v1/trips/refresh-status")
+    assert _is_refresh_trigger(request) is False
+
+
+def test_is_refresh_trigger_ignores_non_post():
+    request = _make_request(method="GET", path="/v1/trips/abc-123/refresh")
+    assert _is_refresh_trigger(request) is False
+
+
+# =============================================================================
+# Cost / abuse ceilings: _check_daily_ceilings
+# =============================================================================
+
+
+@pytest.mark.asyncio
+async def test_ceilings_disabled_skips_all_checks(monkeypatch):
+    monkeypatch.setattr(settings, "enable_cost_ceilings", False)
+
+    called = False
+
+    async def mock_quota(*args, **kwargs):
+        nonlocal called
+        called = True
+        return True, 1, 0
+
+    monkeypatch.setattr(rate_limit_module, "check_and_incr_daily_quota", mock_quota)
+
+    request = _make_request(method="POST", path="/v1/chat/messages")
+    result = await _check_daily_ceilings(request, "user:abc")
+    assert result is None
+    assert called is False
+
+
+@pytest.mark.asyncio
+async def test_daily_api_quota_exceeded_returns_429(monkeypatch):
+    monkeypatch.setattr(settings, "enable_cost_ceilings", True)
+
+    async def mock_quota(identifier, resource, limit, **kwargs):
+        return False, 0, 3600
+
+    monkeypatch.setattr(rate_limit_module, "check_and_incr_daily_quota", mock_quota)
+
+    request = _make_request(path="/v1/trips")
+    result = await _check_daily_ceilings(request, "user:abc")
+    assert result is not None
+    assert result.status_code == 429
+    assert result.headers.get("Retry-After") == "3600"
+
+
+@pytest.mark.asyncio
+async def test_daily_chat_quota_exceeded_returns_429(monkeypatch):
+    monkeypatch.setattr(settings, "enable_cost_ceilings", True)
+
+    async def mock_quota(identifier, resource, limit, **kwargs):
+        # api cap fine, chat cap exceeded.
+        if resource == "chat":
+            return False, 0, 1800
+        return True, 5, 0
+
+    monkeypatch.setattr(rate_limit_module, "check_and_incr_daily_quota", mock_quota)
+
+    request = _make_request(method="POST", path="/v1/chat/messages")
+    result = await _check_daily_ceilings(request, "user:abc")
+    assert result is not None
+    assert result.status_code == 429
+    assert result.headers.get("Retry-After") == "1800"
+
+
+@pytest.mark.asyncio
+async def test_global_groq_budget_tripped_returns_503(monkeypatch):
+    monkeypatch.setattr(settings, "enable_cost_ceilings", True)
+
+    async def allow_quota(*args, **kwargs):
+        return True, 1, 0
+
+    async def tripped(metric, limit, **kwargs):
+        return metric == "groq_tokens"
+
+    monkeypatch.setattr(rate_limit_module, "check_and_incr_daily_quota", allow_quota)
+    monkeypatch.setattr(rate_limit_module, "is_global_budget_tripped", tripped)
+
+    request = _make_request(method="POST", path="/v1/chat/messages")
+    result = await _check_daily_ceilings(request, "user:abc")
+    assert result is not None
+    assert result.status_code == 503
+    body = json.loads(bytes(result.body))
+    assert body["type"] == "https://vacation-price-tracker.dev/problems/global-budget-exceeded"
+
+
+@pytest.mark.asyncio
+async def test_global_skiplagged_budget_tripped_returns_503(monkeypatch):
+    monkeypatch.setattr(settings, "enable_cost_ceilings", True)
+
+    async def allow_quota(*args, **kwargs):
+        return True, 1, 0
+
+    async def tripped(metric, limit, **kwargs):
+        return metric == "skiplagged_calls"
+
+    monkeypatch.setattr(rate_limit_module, "check_and_incr_daily_quota", allow_quota)
+    monkeypatch.setattr(rate_limit_module, "is_global_budget_tripped", tripped)
+
+    request = _make_request(method="POST", path="/v1/trips/refresh-all")
+    result = await _check_daily_ceilings(request, "user:abc")
+    assert result is not None
+    assert result.status_code == 503
+
+
+@pytest.mark.asyncio
+async def test_ceilings_allow_when_under_all_limits(monkeypatch):
+    monkeypatch.setattr(settings, "enable_cost_ceilings", True)
+
+    async def allow_quota(*args, **kwargs):
+        return True, 1, 0
+
+    async def not_tripped(metric, limit, **kwargs):
+        return False
+
+    monkeypatch.setattr(rate_limit_module, "check_and_incr_daily_quota", allow_quota)
+    monkeypatch.setattr(rate_limit_module, "is_global_budget_tripped", not_tripped)
+
+    request = _make_request(method="POST", path="/v1/chat/messages")
+    assert await _check_daily_ceilings(request, "user:abc") is None
+
+
+@pytest.mark.asyncio
+async def test_middleware_blocks_on_daily_ceiling(monkeypatch):
+    """Full middleware: per-minute OK but daily ceiling trips -> rejection."""
+
+    async def mock_check(identifier, *, is_chat=False):
+        return True, 50, 0
+
+    monkeypatch.setattr(rate_limit_module, "_check_rate_limit", mock_check)
+
+    from fastapi.responses import Response as FastResponse
+
+    async def mock_ceiling(request, identifier):
+        return FastResponse(content="blocked", status_code=429)
+
+    monkeypatch.setattr(rate_limit_module, "_check_daily_ceilings", mock_ceiling)
+
+    call_next_called = False
+
+    async def call_next(request):
+        nonlocal call_next_called
+        call_next_called = True
+        return FastResponse(content="OK", status_code=200)
+
+    request = _make_request(path="/v1/trips")
+    response = await rate_limit_middleware(request, call_next)
+    assert response.status_code == 429
+    assert call_next_called is False

--- a/apps/api/tests/middleware/test_rate_limit.py
+++ b/apps/api/tests/middleware/test_rate_limit.py
@@ -8,7 +8,6 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from app.core.cache_keys import CacheKeys
-from app.core.config import settings
 from app.core.constants import CookieNames
 from app.core.security import create_access_token
 from app.middleware import rate_limit as rate_limit_module
@@ -640,28 +639,7 @@ def test_is_refresh_trigger_ignores_non_post():
 
 
 @pytest.mark.asyncio
-async def test_ceilings_disabled_skips_all_checks(monkeypatch):
-    monkeypatch.setattr(settings, "enable_cost_ceilings", False)
-
-    called = False
-
-    async def mock_quota(*args, **kwargs):
-        nonlocal called
-        called = True
-        return True, 1, 0
-
-    monkeypatch.setattr(rate_limit_module, "check_and_incr_daily_quota", mock_quota)
-
-    request = _make_request(method="POST", path="/v1/chat/messages")
-    result = await _check_daily_ceilings(request, "user:abc")
-    assert result is None
-    assert called is False
-
-
-@pytest.mark.asyncio
 async def test_daily_api_quota_exceeded_returns_429(monkeypatch):
-    monkeypatch.setattr(settings, "enable_cost_ceilings", True)
-
     async def mock_quota(identifier, resource, limit, **kwargs):
         return False, 0, 3600
 
@@ -676,8 +654,6 @@ async def test_daily_api_quota_exceeded_returns_429(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_daily_chat_quota_exceeded_returns_429(monkeypatch):
-    monkeypatch.setattr(settings, "enable_cost_ceilings", True)
-
     async def mock_quota(identifier, resource, limit, **kwargs):
         # api cap fine, chat cap exceeded.
         if resource == "chat":
@@ -695,8 +671,6 @@ async def test_daily_chat_quota_exceeded_returns_429(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_global_groq_budget_tripped_returns_503(monkeypatch):
-    monkeypatch.setattr(settings, "enable_cost_ceilings", True)
-
     async def allow_quota(*args, **kwargs):
         return True, 1, 0
 
@@ -716,8 +690,6 @@ async def test_global_groq_budget_tripped_returns_503(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_global_skiplagged_budget_tripped_returns_503(monkeypatch):
-    monkeypatch.setattr(settings, "enable_cost_ceilings", True)
-
     async def allow_quota(*args, **kwargs):
         return True, 1, 0
 
@@ -735,8 +707,6 @@ async def test_global_skiplagged_budget_tripped_returns_503(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_ceilings_allow_when_under_all_limits(monkeypatch):
-    monkeypatch.setattr(settings, "enable_cost_ceilings", True)
-
     async def allow_quota(*args, **kwargs):
         return True, 1, 0
 

--- a/apps/api/tests/services/test_chat.py
+++ b/apps/api/tests/services/test_chat.py
@@ -412,6 +412,36 @@ class TestProcessChatWithTools:
         assert "AI service is currently busy" in error_chunks[0].error
 
     @pytest.mark.asyncio
+    async def test_global_budget_exceeded(self):
+        """A tripped global budget surfaces as a clean error chunk, not a crash."""
+        from app.core.errors import GlobalBudgetExceeded
+
+        mock_client = MagicMock(spec=GroqClient)
+        mock_router = MagicMock(spec=MCPRouter)
+
+        async def mock_chat(*args, **kwargs):
+            if False:
+                yield  # make this an async generator
+            raise GlobalBudgetExceeded("The AI service has reached its daily usage ceiling.")
+
+        mock_client.chat = mock_chat
+
+        messages = [GroqMessage(role="user", content="Hi")]
+        chunks = await collect_chunks(
+            process_chat_with_tools(
+                messages=messages,
+                user_id="user-123",
+                db=None,
+                client=mock_client,
+                router=mock_router,
+            )
+        )
+
+        error_chunks = [c for c in chunks if c.type == ChatChunkType.ERROR]
+        assert len(error_chunks) == 1
+        assert "daily usage ceiling" in error_chunks[0].error
+
+    @pytest.mark.asyncio
     async def test_tool_loop_limit(self):
         """Test that tool loop is limited to prevent infinite loops.
 

--- a/apps/api/tests/test_groq_client.py
+++ b/apps/api/tests/test_groq_client.py
@@ -846,8 +846,6 @@ async def test_chat_meters_token_usage(monkeypatch):
     """A completed streaming chat increments the global Groq token budget."""
     import app.clients.groq as groq_module
 
-    monkeypatch.setattr(config_module.settings, "enable_cost_ceilings", True)
-
     recorded = {}
 
     async def fake_incr(metric, amount, limit, **kwargs):
@@ -888,8 +886,6 @@ async def test_chat_raises_when_budget_tripped(monkeypatch):
     import app.clients.groq as groq_module
     from app.core.errors import GlobalBudgetExceeded
 
-    monkeypatch.setattr(config_module.settings, "enable_cost_ceilings", True)
-
     async def tripped(metric, limit, **kwargs):
         return True
 
@@ -906,42 +902,3 @@ async def test_chat_raises_when_budget_tripped(monkeypatch):
                 pass
 
     create.assert_not_called()
-
-
-@pytest.mark.asyncio
-async def test_chat_skips_metering_when_disabled(monkeypatch):
-    """With ceilings disabled, neither the pre-check nor the meter runs."""
-    import app.clients.groq as groq_module
-
-    monkeypatch.setattr(config_module.settings, "enable_cost_ceilings", False)
-
-    called = {"incr": False, "tripped": False}
-
-    async def fake_incr(*args, **kwargs):
-        called["incr"] = True
-        return True, 0
-
-    async def fake_tripped(*args, **kwargs):
-        called["tripped"] = True
-        return False
-
-    monkeypatch.setattr(groq_module, "incr_and_check_global_budget", fake_incr)
-    monkeypatch.setattr(groq_module, "is_global_budget_tripped", fake_tripped)
-
-    client = GroqClient(api_key="test-key", model="test-model")
-
-    async def mock_stream():
-        delta = MagicMock()
-        delta.content = "Hi"
-        delta.tool_calls = None
-        yield MockChunk(choices=[MockChoice(delta=delta, finish_reason="stop")])
-        yield MockChunk(choices=[], usage=_usage_mock(42))
-
-    mock_async_groq = MagicMock()
-    mock_async_groq.chat.completions.create = AsyncMock(return_value=mock_stream())
-
-    with patch.object(client, "_get_client", return_value=mock_async_groq):
-        async for _ in client.chat([Message(role="user", content="hi")], stream=True):
-            pass
-
-    assert called == {"incr": False, "tripped": False}

--- a/apps/api/tests/test_groq_client.py
+++ b/apps/api/tests/test_groq_client.py
@@ -811,3 +811,137 @@ async def test_chat_tool_call_error_succeeds_on_retry():
     assert call_count == 2
     assert len(chunks) > 0
     assert chunks[0].content == "Success!"
+
+
+# --- Cost ceiling / global budget tests ---
+
+
+def test_build_chat_kwargs_includes_stream_options_when_streaming():
+    """Streaming must request include_usage so token accounting sees usage."""
+    client = GroqClient(api_key="test-key", model="test-model")
+    kwargs = client._build_chat_kwargs(
+        [Message(role="user", content="hi")], None, True, 0.7, None
+    )
+    assert kwargs["stream_options"] == {"include_usage": True}
+
+
+def test_build_chat_kwargs_no_stream_options_when_not_streaming():
+    client = GroqClient(api_key="test-key", model="test-model")
+    kwargs = client._build_chat_kwargs(
+        [Message(role="user", content="hi")], None, False, 0.7, None
+    )
+    assert "stream_options" not in kwargs
+
+
+def _usage_mock(total: int = 15):
+    usage = MagicMock()
+    usage.prompt_tokens = 10
+    usage.completion_tokens = total - 10
+    usage.total_tokens = total
+    return usage
+
+
+@pytest.mark.asyncio
+async def test_chat_meters_token_usage(monkeypatch):
+    """A completed streaming chat increments the global Groq token budget."""
+    import app.clients.groq as groq_module
+
+    monkeypatch.setattr(config_module.settings, "enable_cost_ceilings", True)
+
+    recorded = {}
+
+    async def fake_incr(metric, amount, limit, **kwargs):
+        recorded["metric"] = metric
+        recorded["amount"] = amount
+        return True, amount
+
+    async def not_tripped(metric, limit, **kwargs):
+        return False
+
+    monkeypatch.setattr(groq_module, "incr_and_check_global_budget", fake_incr)
+    monkeypatch.setattr(groq_module, "is_global_budget_tripped", not_tripped)
+
+    client = GroqClient(api_key="test-key", model="test-model")
+
+    async def mock_stream():
+        delta = MagicMock()
+        delta.content = "Hi"
+        delta.tool_calls = None
+        yield MockChunk(choices=[MockChoice(delta=delta, finish_reason="stop")])
+        # Terminal usage-only chunk (empty choices) as emitted with include_usage.
+        yield MockChunk(choices=[], usage=_usage_mock(42))
+
+    mock_async_groq = MagicMock()
+    mock_async_groq.chat.completions.create = AsyncMock(return_value=mock_stream())
+
+    with patch.object(client, "_get_client", return_value=mock_async_groq):
+        async for _ in client.chat([Message(role="user", content="hi")], stream=True):
+            pass
+
+    assert recorded["metric"] == "groq_tokens"
+    assert recorded["amount"] == 42
+
+
+@pytest.mark.asyncio
+async def test_chat_raises_when_budget_tripped(monkeypatch):
+    """When the breaker is already tripped, chat fails fast before calling Groq."""
+    import app.clients.groq as groq_module
+    from app.core.errors import GlobalBudgetExceeded
+
+    monkeypatch.setattr(config_module.settings, "enable_cost_ceilings", True)
+
+    async def tripped(metric, limit, **kwargs):
+        return True
+
+    monkeypatch.setattr(groq_module, "is_global_budget_tripped", tripped)
+
+    client = GroqClient(api_key="test-key", model="test-model")
+    create = AsyncMock()
+    mock_async_groq = MagicMock()
+    mock_async_groq.chat.completions.create = create
+
+    with patch.object(client, "_get_client", return_value=mock_async_groq):  # noqa: SIM117
+        with pytest.raises(GlobalBudgetExceeded):
+            async for _ in client.chat([Message(role="user", content="hi")], stream=True):
+                pass
+
+    create.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_chat_skips_metering_when_disabled(monkeypatch):
+    """With ceilings disabled, neither the pre-check nor the meter runs."""
+    import app.clients.groq as groq_module
+
+    monkeypatch.setattr(config_module.settings, "enable_cost_ceilings", False)
+
+    called = {"incr": False, "tripped": False}
+
+    async def fake_incr(*args, **kwargs):
+        called["incr"] = True
+        return True, 0
+
+    async def fake_tripped(*args, **kwargs):
+        called["tripped"] = True
+        return False
+
+    monkeypatch.setattr(groq_module, "incr_and_check_global_budget", fake_incr)
+    monkeypatch.setattr(groq_module, "is_global_budget_tripped", fake_tripped)
+
+    client = GroqClient(api_key="test-key", model="test-model")
+
+    async def mock_stream():
+        delta = MagicMock()
+        delta.content = "Hi"
+        delta.tool_calls = None
+        yield MockChunk(choices=[MockChoice(delta=delta, finish_reason="stop")])
+        yield MockChunk(choices=[], usage=_usage_mock(42))
+
+    mock_async_groq = MagicMock()
+    mock_async_groq.chat.completions.create = AsyncMock(return_value=mock_stream())
+
+    with patch.object(client, "_get_client", return_value=mock_async_groq):
+        async for _ in client.chat([Message(role="user", content="hi")], stream=True):
+            pass
+
+    assert called == {"incr": False, "tripped": False}

--- a/apps/api/tests/test_quota.py
+++ b/apps/api/tests/test_quota.py
@@ -1,0 +1,159 @@
+"""Tests for cost/abuse ceiling helpers (per-user daily quota + global budget)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock
+
+import pytest
+from app.core import quota
+from app.core.cache_keys import CacheTTL
+
+# =============================================================================
+# _seconds_to_utc_midnight / _day_bucket
+# =============================================================================
+
+
+def test_seconds_to_utc_midnight_midday():
+    now = datetime(2026, 6, 23, 12, 0, 0, tzinfo=UTC)
+    # 12 hours to midnight.
+    assert quota._seconds_to_utc_midnight(now) == 12 * 3600
+
+
+def test_seconds_to_utc_midnight_floor_near_midnight():
+    now = datetime(2026, 6, 23, 23, 59, 59, tzinfo=UTC)
+    # 1 second to midnight, but floored to the minimum TTL.
+    assert quota._seconds_to_utc_midnight(now) == CacheTTL.DAILY_QUOTA_MIN_TTL
+
+
+def test_day_bucket_is_utc_yyyymmdd():
+    now = datetime(2026, 6, 23, 5, 30, 0, tzinfo=UTC)
+    assert quota._day_bucket(now) == "20260623"
+
+
+# =============================================================================
+# check_and_incr_daily_quota
+# =============================================================================
+
+
+@pytest.mark.asyncio
+async def test_daily_quota_allowed(monkeypatch):
+    monkeypatch.setattr(quota.redis_client, "eval", AsyncMock(return_value=[1, 41, 0]))
+    allowed, remaining, retry_after = await quota.check_and_incr_daily_quota(
+        "user:abc", "chat", 42
+    )
+    assert allowed is True
+    assert remaining == 41
+    assert retry_after == 0
+
+
+@pytest.mark.asyncio
+async def test_daily_quota_exceeded_returns_retry_after(monkeypatch):
+    monkeypatch.setattr(quota.redis_client, "eval", AsyncMock(return_value=[0, 0, 3600]))
+    allowed, remaining, retry_after = await quota.check_and_incr_daily_quota(
+        "user:abc", "chat", 42
+    )
+    assert allowed is False
+    assert remaining == 0
+    assert retry_after == 3600
+
+
+@pytest.mark.asyncio
+async def test_daily_quota_fails_open_on_redis_error(monkeypatch, caplog):
+    monkeypatch.setattr(
+        quota.redis_client, "eval", AsyncMock(side_effect=RuntimeError("redis down"))
+    )
+    with caplog.at_level("WARNING"):
+        allowed, remaining, retry_after = await quota.check_and_incr_daily_quota(
+            "user:abc", "api", 100
+        )
+    assert allowed is True
+    assert remaining == 100
+    assert retry_after == 0
+    assert "Daily quota check failed" in caplog.text
+
+
+# =============================================================================
+# incr_and_check_global_budget
+# =============================================================================
+
+
+@pytest.mark.asyncio
+async def test_global_budget_within(monkeypatch):
+    monkeypatch.setattr(quota.redis_client, "eval", AsyncMock(return_value=[1, 500]))
+    within, total = await quota.incr_and_check_global_budget("groq_tokens", 500, 1000)
+    assert within is True
+    assert total == 500
+
+
+@pytest.mark.asyncio
+async def test_global_budget_trips_and_logs_once(monkeypatch, caplog):
+    # total jumps from <=limit to >limit on this increment -> log the trip.
+    monkeypatch.setattr(quota.redis_client, "eval", AsyncMock(return_value=[0, 1200]))
+    with caplog.at_level("WARNING"):
+        within, total = await quota.incr_and_check_global_budget(
+            "groq_tokens", 300, 1000
+        )
+    assert within is False
+    assert total == 1200
+    assert "Global budget breaker tripped" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_global_budget_over_does_not_relog_after_trip(monkeypatch, caplog):
+    # Already well over the limit before this increment -> no fresh trip log.
+    monkeypatch.setattr(quota.redis_client, "eval", AsyncMock(return_value=[0, 5000]))
+    with caplog.at_level("WARNING"):
+        within, total = await quota.incr_and_check_global_budget(
+            "groq_tokens", 100, 1000
+        )
+    assert within is False
+    assert total == 5000
+    assert "Global budget breaker tripped" not in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_global_budget_fails_open_on_redis_error(monkeypatch):
+    monkeypatch.setattr(
+        quota.redis_client, "eval", AsyncMock(side_effect=RuntimeError("redis down"))
+    )
+    within, total = await quota.incr_and_check_global_budget("skiplagged_calls", 1, 100)
+    assert within is True
+    assert total == 0
+
+
+# =============================================================================
+# is_global_budget_tripped
+# =============================================================================
+
+
+@pytest.mark.asyncio
+async def test_is_tripped_false_when_no_key(monkeypatch):
+    monkeypatch.setattr(quota.redis_client, "get", AsyncMock(return_value=None))
+    assert await quota.is_global_budget_tripped("groq_tokens", 1000) is False
+
+
+@pytest.mark.asyncio
+async def test_is_tripped_false_under_limit(monkeypatch):
+    monkeypatch.setattr(quota.redis_client, "get", AsyncMock(return_value="999"))
+    assert await quota.is_global_budget_tripped("groq_tokens", 1000) is False
+
+
+@pytest.mark.asyncio
+async def test_is_tripped_true_over_limit(monkeypatch):
+    monkeypatch.setattr(quota.redis_client, "get", AsyncMock(return_value="1001"))
+    assert await quota.is_global_budget_tripped("groq_tokens", 1000) is True
+
+
+@pytest.mark.asyncio
+async def test_is_tripped_false_on_garbage_value(monkeypatch):
+    monkeypatch.setattr(quota.redis_client, "get", AsyncMock(return_value="not-a-number"))
+    assert await quota.is_global_budget_tripped("groq_tokens", 1000) is False
+
+
+@pytest.mark.asyncio
+async def test_is_tripped_fails_open_on_redis_error(monkeypatch):
+    monkeypatch.setattr(
+        quota.redis_client, "get", AsyncMock(side_effect=RuntimeError("redis down"))
+    )
+    assert await quota.is_global_budget_tripped("groq_tokens", 1000) is False

--- a/apps/worker/tests/test_price_check_activities.py
+++ b/apps/worker/tests/test_price_check_activities.py
@@ -1099,3 +1099,49 @@ def test_budget_application_error_is_non_retryable():
     assert isinstance(err, ApplicationError)
     assert err.non_retryable is True
     assert err.type == "GlobalBudgetExceeded"
+
+
+@pytest.mark.asyncio
+async def test_fetch_hotels_budget_trip_during_details_is_non_retryable(monkeypatch):
+    """A budget trip mid get_hotel_details must surface, not be swallowed by the
+    per-hotel fallback."""
+    from decimal import Decimal
+    from unittest.mock import AsyncMock, patch
+
+    from app.core.errors import GlobalBudgetExceeded
+    from app.schemas.hotel_search import HotelSearchHotel, HotelSearchResult
+    from temporalio.exceptions import ApplicationError
+
+    hotels = [
+        HotelSearchHotel(
+            id=f"hotel_{i}",
+            name=f"Hotel {i}",
+            price_per_night=Decimal(str(50 + i * 10)),
+            price_currency="USD",
+            provider="skiplagged",
+        )
+        for i in range(3)
+    ]
+    mock_hotel_result = HotelSearchResult(
+        hotels=hotels,
+        city="PAR",
+        checkin="2026-06-15",
+        checkout="2026-06-22",
+        total_results=3,
+        success=True,
+    )
+
+    mock_client = AsyncMock()
+    mock_client.search_hotels_all = AsyncMock(return_value=mock_hotel_result)
+    # search_hotels_all passed the gate; the breaker trips during details.
+    mock_client.get_hotel_details = AsyncMock(
+        side_effect=GlobalBudgetExceeded("daily ceiling reached")
+    )
+
+    monkeypatch.setattr(pc.settings, "mock_skiplagged_api", False)
+    with patch("worker.activities.price_check.SkiplaggedClient", return_value=mock_client):
+        with pytest.raises(ApplicationError) as exc_info:
+            await pc.fetch_hotels_activity(sample_trip_details)
+
+    assert exc_info.value.non_retryable is True
+    assert exc_info.value.type == "GlobalBudgetExceeded"

--- a/apps/worker/tests/test_price_check_activities.py
+++ b/apps/worker/tests/test_price_check_activities.py
@@ -1045,3 +1045,57 @@ async def test_fetch_hotels_activity_falls_back_to_destination_code(monkeypatch,
     await pc.fetch_hotels_activity(trip)
 
     assert captured["city"] == "MCO"
+
+
+@pytest.mark.asyncio
+async def test_fetch_flights_budget_exceeded_is_non_retryable(monkeypatch):
+    """A tripped global budget surfaces as a non-retryable Temporal error."""
+    from unittest.mock import AsyncMock, patch
+
+    from app.core.errors import GlobalBudgetExceeded
+    from temporalio.exceptions import ApplicationError
+
+    mock_client = AsyncMock()
+    mock_client.search_flights_all = AsyncMock(
+        side_effect=GlobalBudgetExceeded("daily ceiling reached")
+    )
+
+    monkeypatch.setattr(pc.settings, "mock_skiplagged_api", False)
+    with patch("worker.activities.price_check.SkiplaggedClient", return_value=mock_client):
+        with pytest.raises(ApplicationError) as exc_info:
+            await pc.fetch_flights_activity(_trip_details())
+
+    assert exc_info.value.non_retryable is True
+    assert exc_info.value.type == "GlobalBudgetExceeded"
+
+
+@pytest.mark.asyncio
+async def test_fetch_hotels_budget_exceeded_is_non_retryable(monkeypatch):
+    """Hotel fetch also marks a tripped budget non-retryable."""
+    from unittest.mock import AsyncMock, patch
+
+    from app.core.errors import GlobalBudgetExceeded
+    from temporalio.exceptions import ApplicationError
+
+    mock_client = AsyncMock()
+    mock_client.search_hotels_all = AsyncMock(
+        side_effect=GlobalBudgetExceeded("daily ceiling reached")
+    )
+
+    monkeypatch.setattr(pc.settings, "mock_skiplagged_api", False)
+    with patch("worker.activities.price_check.SkiplaggedClient", return_value=mock_client):
+        with pytest.raises(ApplicationError) as exc_info:
+            await pc.fetch_hotels_activity(_trip_details())
+
+    assert exc_info.value.non_retryable is True
+    assert exc_info.value.type == "GlobalBudgetExceeded"
+
+
+def test_budget_application_error_is_non_retryable():
+    from app.core.errors import GlobalBudgetExceeded
+    from temporalio.exceptions import ApplicationError
+
+    err = pc._budget_application_error(GlobalBudgetExceeded("ceiling"))
+    assert isinstance(err, ApplicationError)
+    assert err.non_retryable is True
+    assert err.type == "GlobalBudgetExceeded"

--- a/apps/worker/worker/activities/price_check.py
+++ b/apps/worker/worker/activities/price_check.py
@@ -262,7 +262,10 @@ async def fetch_hotels_activity(trip: TripDetails) -> FetchResult:
         trip["trip_id"],
     )
 
-    # Fetch details concurrently (with fallback to search-level data on failure)
+    # Fetch details concurrently (with fallback to search-level data on failure).
+    # A tripped global budget must NOT be swallowed by the fallback — let it
+    # propagate so the remaining detail calls are abandoned (no further
+    # increments) and the activity fails non-retriably.
     async def _fetch_one(hotel):
         try:
             detail = await client.get_hotel_details(
@@ -273,11 +276,16 @@ async def fetch_hotels_activity(trip: TripDetails) -> FetchResult:
                 rooms=hotel_prefs["rooms"],
             )
             return _normalize_hotel_detail(detail, hotel)
+        except GlobalBudgetExceeded:
+            raise
         except Exception as exc:
             logger.warning("Failed to get details for hotel_id=%s: %s", hotel.id, exc)
             return _hotel_to_offer_dict(hotel)
 
-    offers = await asyncio.gather(*[_fetch_one(h) for h in top_hotels])
+    try:
+        offers = await asyncio.gather(*[_fetch_one(h) for h in top_hotels])
+    except GlobalBudgetExceeded as exc:
+        raise _budget_application_error(exc) from exc
 
     logger.info("Fetched %d hotel offers for trip_id=%s", len(offers), trip["trip_id"])
     return {

--- a/apps/worker/worker/activities/price_check.py
+++ b/apps/worker/worker/activities/price_check.py
@@ -9,6 +9,7 @@ from app.clients.skiplagged import SkiplaggedClient, SkiplaggedMCPError
 from app.clients.skiplagged_mock import mock_flight_search, mock_hotel_search
 from app.clients.skiplagged_parser import parse_flight_segments
 from app.core.config import settings
+from app.core.errors import GlobalBudgetExceeded
 from app.core.telemetry import langfuse_context, observe
 from app.db.session import AsyncSessionLocal
 from app.models.price_snapshot import PriceSnapshot
@@ -16,6 +17,7 @@ from app.models.trip import Trip
 from app.models.trip_prefs import TripFlightPrefs, TripHotelPrefs
 from sqlmodel import select
 from temporalio import activity
+from temporalio.exceptions import ApplicationError
 
 from worker.types import FetchResult, FilterInput, FilterOutput, SaveSnapshotInput, TripDetails
 
@@ -32,6 +34,17 @@ NESTED_PRICE_FIELDS = ("total", "total_price", "amount", "grandTotal", "base")
 
 # Maximum number of hotels to fetch full details for (avoids API abuse)
 MAX_HOTEL_DETAIL_CALLS = 20
+
+
+def _budget_application_error(exc: GlobalBudgetExceeded) -> ApplicationError:
+    """Wrap a tripped global budget breaker as a non-retriable Temporal error.
+
+    Retrying won't help while the breaker is tripped (it resets at UTC midnight),
+    so we mark it non-retryable. With the workflow's `return_exceptions=True`, a
+    one-sided trip still snapshots the other side's data with this error recorded.
+    """
+    logger.warning("Global budget breaker tripped during fetch: %s", exc)
+    return ApplicationError(str(exc), type="GlobalBudgetExceeded", non_retryable=True)
 
 
 @activity.defn
@@ -138,6 +151,8 @@ async def fetch_flights_activity(trip: TripDetails) -> FetchResult:
             max_stops=max_stops,
             max_pages=4,
         )
+    except GlobalBudgetExceeded as exc:
+        raise _budget_application_error(exc) from exc
     except SkiplaggedMCPError as exc:
         logger.warning("Flight fetch failed for trip_id=%s", trip["trip_id"], exc_info=exc)
         raise
@@ -230,6 +245,8 @@ async def fetch_hotels_activity(trip: TripDetails) -> FetchResult:
             rooms=hotel_prefs["rooms"],
             max_pages=4,
         )
+    except GlobalBudgetExceeded as exc:
+        raise _budget_application_error(exc) from exc
     except SkiplaggedMCPError as exc:
         logger.warning("Hotel search failed for trip_id=%s", trip["trip_id"], exc_info=exc)
         raise


### PR DESCRIPTION
## Summary

- The per-minute rate limiter left two unbounded-bill vectors: a user parked at the chat limit for hours, and a leaked session / aggregate abuse running up the **Groq** (paid LLM) bill or **Skiplagged** (public MCP) call volume. This adds Redis-backed **per-user daily quotas** and a **global daily spend circuit-breaker** — always on (like the per-minute limiter), auto-resetting at UTC midnight, failing open on Redis errors.
- **Per-user daily quotas** in `rate_limit_middleware`: an overall API cap (`DAILY_QUOTA_PER_USER`, 2000) and a stricter cap on message-producing chat (`CHAT_DAILY_QUOTA_PER_USER`, 200) → 429 with `Retry-After` = seconds to midnight.
- **Global budget guard (hybrid metric)** metered at the two shared provider chokepoints so the worker's scheduled refreshes are covered too: `groq.chat()` adds `total_tokens` (`GLOBAL_DAILY_GROQ_TOKEN_BUDGET`), `skiplagged._call_mcp()` adds 1 per call (`GLOBAL_DAILY_SKIPLAGGED_CALL_BUDGET`). When a metric crosses its ceiling, the chat/refresh edge returns 503 and the clients raise `GlobalBudgetExceeded` so in-flight chat (SSE error chunk) and worker activities (non-retriable Temporal error) degrade gracefully.
- Also fixes Groq **streaming usage capture** (`stream_options={"include_usage": True}`) — the token meter and Langfuse accounting both depend on it (previously a no-op on the streaming path).

New `app/core/quota.py` (Lua-atomic helpers), `GlobalBudgetExceeded` (503) error, config fields, and docs in `.env.example` + api/root `CLAUDE.md`.

### Config

The feature has **no on/off flag** — it's always on, consistent with the per-minute limiter. The **four numeric limits are the only knobs**, all surfaced in `.env.example` so they're discoverable and tunable; set one very high to effectively disable it.

```
CHAT_DAILY_QUOTA_PER_USER=200
DAILY_QUOTA_PER_USER=2000
GLOBAL_DAILY_GROQ_TOKEN_BUDGET=50000000
GLOBAL_DAILY_SKIPLAGGED_CALL_BUDGET=50000
```

### Design decisions (confirmed)
- **Metric:** hybrid — Groq by tokens (paid, accurate $ proxy), Skiplagged by call count (free, abuse/ban risk).
- **Scope:** API edge + provider chokepoints, so worker scheduled refreshes are metered.
- **Redis down:** fail-open (availability-first). Residual risk — a Redis outage disables all limiters at once — is documented in `apps/api/CLAUDE.md`.

## Test plan

- [x] `pnpm verify` green (build, lint, typecheck, coverage ≥95% on `api` and `worker`, audits)
- [x] `apps/api/tests/test_quota.py` — seconds-to-midnight floor, daily quota allow/exceed/fail-open, budget within/trip/fail-open, breaker read check
- [x] Middleware integration — daily quota 429, breaker 503 for chat + refresh, refresh-path matching (incl. not gating `refresh-status`)
- [x] Groq — `stream_options` present when streaming, token metering, pre-check raise
- [x] Skiplagged — per-`_call_mcp` increment, raise-before-send when over budget
- [x] Worker — `GlobalBudgetExceeded` → non-retriable `ApplicationError` (incl. trip during `get_hotel_details`); partial-snapshot path preserved
- [x] Chat — `GlobalBudgetExceeded` surfaces as a clean SSE error chunk, not a crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CLU2qzji7MCM2UREz8yaZR