### PR TITLE
fix: resolve SonarCloud new-code coverage (web lcov paths + admin.py)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -153,6 +153,25 @@ Playwright (requires the Docker stack up).
 
 Coverage gates: **95%** for both Python apps (`api`, `worker`).
 
+### SonarCloud coverage (run locally before a PR)
+
+CI computes coverage in the Next.js + Python workflows, then a **separate**
+SonarQube workflow downloads those reports and scans (`sonar-project.properties`).
+That scan can under-report **silently**: SonarCloud resolves every path in a
+coverage report against the repo root, and any path that doesn't resolve is
+dropped and shown as **0% on new code** with no error (this is exactly how jest's
+`SF:src/...` lcov paths — relative to `apps/web` — vanished). To catch it before
+pushing:
+
+- **`pnpm sonar:verify`** — regenerates the same reports CI feeds Sonar
+  (`test:coverage` for web/api/worker) and checks every path resolves to a real
+  file. `--no-tests` validates existing reports only; `--scan` also runs the real
+  scanner (needs `SONAR_TOKEN`).
+- **`pnpm sonar:check`** — just the path/coverage validator over existing reports.
+
+The web `test:coverage` target reroots its lcov to repo-root-relative paths via
+`scripts/lcov-reroot.mjs`, so the report Sonar consumes always maps onto real files.
+
 ## Verification Preference
 
 - After code changes, automatically run the most relevant tests/checks without

--- a/apps/api/app/routers/admin.py
+++ b/apps/api/app/routers/admin.py
@@ -159,7 +159,7 @@ async def admin_sql(request: Request, session: AsyncSession = Depends(get_admin_
     dialect = session.bind.dialect.name if session.bind is not None else ""
     started = time.monotonic()
     try:
-        if dialect == "postgresql":
+        if dialect == "postgresql":  # pragma: no cover - Postgres-only; tests run on SQLite
             await session.execute(text("SET TRANSACTION READ ONLY"))
             await session.execute(text(f"SET LOCAL statement_timeout = {STATEMENT_TIMEOUT_MS}"))
         rows = (await session.execute(text(query))).mappings().all()

--- a/apps/api/tests/test_admin_sql.py
+++ b/apps/api/tests/test_admin_sql.py
@@ -11,6 +11,7 @@ These run against the SQLite test session, so the Postgres-specific guards
 `_classify_db_error` unit tests rather than a live Postgres backend.
 """
 
+from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 import pytest
@@ -107,6 +108,63 @@ class TestClassifyDbError:
 
 
 # ---------------------------------------------------------------------------
+# Client-IP resolution (header precedence)
+# ---------------------------------------------------------------------------
+class TestClientIp:
+    def _request(self, headers, *, client_host="1.2.3.4"):
+        client = SimpleNamespace(host=client_host) if client_host is not None else None
+        return SimpleNamespace(headers=headers, client=client)
+
+    def test_prefers_x_forwarded_for(self):
+        from app.routers.admin import _client_ip
+
+        req = self._request({"x-forwarded-for": "9.9.9.9, 8.8.8.8"})
+        assert _client_ip(req) == "9.9.9.9"
+
+    def test_falls_back_to_x_real_ip(self):
+        from app.routers.admin import _client_ip
+
+        req = self._request({"x-real-ip": "  7.7.7.7  "})
+        assert _client_ip(req) == "7.7.7.7"
+
+    def test_falls_back_to_client_host(self):
+        from app.routers.admin import _client_ip
+
+        assert _client_ip(self._request({}, client_host="5.5.5.5")) == "5.5.5.5"
+
+    def test_anonymous_when_no_client(self):
+        from app.routers.admin import _client_ip
+
+        assert _client_ip(self._request({}, client_host=None)) == "anonymous"
+
+
+# ---------------------------------------------------------------------------
+# Admin session factory (lazy engine creation)
+# ---------------------------------------------------------------------------
+async def test_get_admin_session_creates_and_yields(monkeypatch, tmp_path):
+    import app.routers.admin as admin_module
+    from app.core.config import settings
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+    # A file-backed SQLite URL uses a real connection pool, so the engine's
+    # pool_size/max_overflow kwargs are accepted (the :memory: StaticPool isn't).
+    db_url = f"sqlite+aiosqlite:///{tmp_path / 'admin.db'}"
+    monkeypatch.setattr(settings, "admin_query_database_url", None)
+    monkeypatch.setattr(settings, "database_url", db_url)
+    monkeypatch.setattr(admin_module, "_admin_sessionmaker", None)
+
+    agen = admin_module.get_admin_session()
+    session = await agen.__anext__()
+    try:
+        assert isinstance(session, AsyncSession)
+        # Sessionmaker is memoized after the first call.
+        assert admin_module._admin_sessionmaker is not None
+        assert admin_module._get_admin_sessionmaker() is admin_module._admin_sessionmaker
+    finally:
+        await agen.aclose()
+
+
+# ---------------------------------------------------------------------------
 # Endpoint
 # ---------------------------------------------------------------------------
 @pytest.fixture
@@ -197,6 +255,15 @@ class TestAdminSqlExecution:
         resp = admin_client.post("/v1/admin/sql", json=[1, 2, 3], headers=_auth())
         assert resp.status_code == 400
 
+    def test_invalid_json_body(self, admin_client):
+        resp = admin_client.post(
+            "/v1/admin/sql",
+            content="not json",
+            headers={**_auth(), "Content-Type": "application/json"},
+        )
+        assert resp.status_code == 400
+        assert resp.json()["error"] == "bad_request"
+
     def test_invalid_sql_returns_server_error(self, admin_client):
         resp = admin_client.post(
             "/v1/admin/sql",
@@ -229,3 +296,55 @@ class TestAdminSqlRateLimit:
             "/v1/admin/sql", json={"query": "SELECT 1"}, headers=_auth()
         )
         assert resp.status_code == 429
+
+    def test_first_request_sets_window_expiry(self, admin_client, mock_redis):
+        # count == 1 is the first hit in a fresh window; the limiter sets the TTL.
+        mock_redis.incr = AsyncMock(return_value=1)
+        mock_redis.expire = AsyncMock()
+        resp = admin_client.post(
+            "/v1/admin/sql", json={"query": "SELECT 1 AS n"}, headers=_auth()
+        )
+        assert resp.status_code == 200
+        mock_redis.expire.assert_awaited_once()
+
+
+class TestAdminSqlDbErrors:
+    """The DB-error branches (timeout/read-only) via a session whose execute
+    raises a wrapped driver error carrying a SQLSTATE."""
+
+    @pytest.fixture
+    def app_with_raising_session(self, admin_app):
+        import app.routers.admin as admin_module
+
+        def _make(sqlstate):
+            class _RaisingSession:
+                bind = None  # dialect == "" → skips the Postgres-only guards
+
+                async def execute(self, *args, **kwargs):
+                    orig = SimpleNamespace(sqlstate=sqlstate)
+                    exc = RuntimeError("boom")
+                    exc.orig = orig
+                    raise exc
+
+                async def rollback(self):
+                    return None
+
+            async def override():
+                yield _RaisingSession()
+
+            admin_app.dependency_overrides[admin_module.get_admin_session] = override
+            return admin_app
+
+        return _make
+
+    def test_timeout_maps_to_504(self, app_with_raising_session):
+        client = TestClient(app_with_raising_session("57014"))
+        resp = client.post("/v1/admin/sql", json={"query": "SELECT 1"}, headers=_auth())
+        assert resp.status_code == 504
+        assert resp.json()["error"] == "timeout"
+
+    def test_read_only_maps_to_422(self, app_with_raising_session):
+        client = TestClient(app_with_raising_session("25006"))
+        resp = client.post("/v1/admin/sql", json={"query": "SELECT 1"}, headers=_auth())
+        assert resp.status_code == 422
+        assert resp.json()["error"] == "query_rejected"

--- a/apps/web/project.json
+++ b/apps/web/project.json
@@ -77,7 +77,11 @@
       "inputs": ["default"],
       "outputs": ["{projectRoot}/coverage"],
       "options": {
-        "command": "NODE_NO_WARNINGS=1 pnpm jest --watchAll=false --coverage",
+        "commands": [
+          "NODE_NO_WARNINGS=1 pnpm jest --watchAll=false --coverage",
+          "node ../../scripts/lcov-reroot.mjs coverage/lcov.info apps/web/"
+        ],
+        "parallel": false,
         "cwd": "apps/web",
         "forwardAllArgs": false
       }

--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
     "affected:lint": "nx affected -t lint",
     "affected:test": "nx affected -t test",
     "sonar": "sonar-scanner",
+    "sonar:verify": "./scripts/sonar-local.sh",
+    "sonar:check": "node scripts/sonar-coverage-check.mjs",
     "web:dev": "nx dev web",
     "web:dev:http": "nx run web:dev --configuration=development",
     "web:build": "nx build web",

--- a/scripts/lcov-reroot.mjs
+++ b/scripts/lcov-reroot.mjs
@@ -1,0 +1,43 @@
+#!/usr/bin/env node
+// Rewrite the `SF:` source paths in an lcov report so they are relative to the
+// repo root instead of the app directory.
+//
+// Why: Next.js/jest emits coverage paths relative to `apps/web` (e.g.
+// `SF:src/lib/price-history.ts`). The SonarCloud scanner runs at the repo root
+// and resolves lcov paths against `sonar.projectBaseDir` (the repo root), so an
+// unprefixed `src/...` path maps to nothing on disk. Sonar then silently treats
+// every web file as having NO coverage and reports 0% on new code — even though
+// the tests fully exercise the file. Prefixing each path with `apps/web/` makes
+// it resolve to the real file and the coverage lands.
+//
+// Usage: node scripts/lcov-reroot.mjs <lcov-file> <path-prefix>
+//   node scripts/lcov-reroot.mjs apps/web/coverage/lcov.info apps/web/
+//
+// Idempotent: paths already carrying the prefix (or absolute paths) are left
+// untouched, so it is safe to run repeatedly.
+
+import { readFileSync, writeFileSync, existsSync } from "node:fs";
+
+const [file, prefix] = process.argv.slice(2);
+
+if (!file || !prefix) {
+  console.error("usage: node scripts/lcov-reroot.mjs <lcov-file> <path-prefix>");
+  process.exit(2);
+}
+
+if (!existsSync(file)) {
+  console.error(`lcov-reroot: report not found: ${file}`);
+  process.exit(1);
+}
+
+const isAbsolute = (p) => p.startsWith("/") || /^[A-Za-z]:[\\/]/.test(p);
+
+let rewritten = 0;
+const out = readFileSync(file, "utf8").replace(/^SF:(.*)$/gm, (match, p) => {
+  if (p.startsWith(prefix) || isAbsolute(p)) return match;
+  rewritten += 1;
+  return `SF:${prefix}${p}`;
+});
+
+writeFileSync(file, out);
+console.log(`lcov-reroot: prefixed ${rewritten} source path(s) in ${file} with "${prefix}"`);

--- a/scripts/sonar-coverage-check.mjs
+++ b/scripts/sonar-coverage-check.mjs
@@ -1,0 +1,175 @@
+#!/usr/bin/env node
+// Locally reproduce the part of the SonarCloud scan that silently breaks:
+// whether the coverage reports we hand to the scanner actually map onto files
+// in the repo.
+//
+// SonarCloud resolves every path in a coverage report against the repo root
+// (`sonar.projectBaseDir`). If a path doesn't resolve, Sonar does NOT fail —
+// it just drops that file's coverage and reports it as 0% on new code, which is
+// exactly the failure this guards against (jest emits `SF:src/...` relative to
+// `apps/web`, which is nothing from the repo root).
+//
+// This reads the same report paths the real scan uses from
+// `sonar-project.properties`, parses each lcov/cobertura report, and verifies
+// every referenced source file exists relative to the repo root. It prints a
+// per-report summary and a per-file coverage table, and exits non-zero if any
+// path fails to resolve or a configured report is missing.
+//
+// Run AFTER generating coverage (`pnpm test:coverage`), or use the
+// `scripts/sonar-local.sh` wrapper which does both. No SONAR_TOKEN needed.
+
+import { readFileSync, existsSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join, resolve } from "node:path";
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const propsPath = join(ROOT, "sonar-project.properties");
+
+const RED = "\x1b[31m";
+const GREEN = "\x1b[32m";
+const YELLOW = "\x1b[33m";
+const DIM = "\x1b[2m";
+const BOLD = "\x1b[1m";
+const NC = "\x1b[0m";
+
+/** Parse sonar-project.properties into a flat key→value map (handles `\` line continuations). */
+function parseProps(text) {
+  const out = {};
+  const lines = text.split("\n");
+  for (let i = 0; i < lines.length; i++) {
+    let line = lines[i];
+    if (!line.trim() || line.trim().startsWith("#")) continue;
+    const eq = line.indexOf("=");
+    if (eq === -1) continue;
+    const key = line.slice(0, eq).trim();
+    let value = line.slice(eq + 1);
+    while (value.trimEnd().endsWith("\\")) {
+      value = value.trimEnd().slice(0, -1) + (lines[++i] ?? "");
+    }
+    out[key] = value
+      .split(",")
+      .map((s) => s.trim())
+      .filter(Boolean)
+      .join(",");
+  }
+  return out;
+}
+
+/** Extract { file, found, total } records from an lcov report. */
+function parseLcov(text) {
+  const records = [];
+  let file = null;
+  let found = 0;
+  let hit = 0;
+  for (const line of text.split("\n")) {
+    if (line.startsWith("SF:")) {
+      file = line.slice(3).trim();
+      found = 0;
+      hit = 0;
+    } else if (line.startsWith("DA:")) {
+      const count = Number(line.split(",")[1]);
+      found += 1;
+      if (count > 0) hit += 1;
+    } else if (line.startsWith("end_of_record") && file) {
+      records.push({ file, total: found, covered: hit });
+      file = null;
+    }
+  }
+  return records;
+}
+
+/** Extract { file, total, covered } records from a Cobertura (coverage.py) XML report. */
+function parseCobertura(text) {
+  const records = [];
+  const classRe = /<class\b[^>]*\bfilename="([^"]+)"[^>]*>([\s\S]*?)<\/class>/g;
+  let m;
+  while ((m = classRe.exec(text)) !== null) {
+    const file = m[1];
+    const body = m[2];
+    let total = 0;
+    let covered = 0;
+    const lineRe = /<line\b[^>]*\bhits="(\d+)"[^>]*\/?>/g;
+    let lm;
+    while ((lm = lineRe.exec(body)) !== null) {
+      total += 1;
+      if (Number(lm[1]) > 0) covered += 1;
+    }
+    records.push({ file, total, covered });
+  }
+  return records;
+}
+
+function pct(covered, total) {
+  if (total === 0) return "100.0%";
+  return `${((covered / total) * 100).toFixed(1)}%`;
+}
+
+const props = parseProps(readFileSync(propsPath, "utf8"));
+const reports = [
+  ...(props["sonar.javascript.lcov.reportPaths"]?.split(",") ?? []).map((p) => ({
+    path: p,
+    kind: "lcov",
+  })),
+  ...(props["sonar.python.coverage.reportPaths"]?.split(",") ?? []).map((p) => ({
+    path: p,
+    kind: "cobertura",
+  })),
+].filter((r) => r.path);
+
+let problems = 0;
+let missingReports = 0;
+
+console.log(`${BOLD}SonarCloud coverage path check${NC} ${DIM}(repo root: ${ROOT})${NC}\n`);
+
+for (const { path, kind } of reports) {
+  const abs = join(ROOT, path);
+  if (!existsSync(abs)) {
+    console.log(`${YELLOW}⚠ missing report${NC} ${path} ${DIM}(run pnpm test:coverage first)${NC}`);
+    missingReports += 1;
+    continue;
+  }
+
+  const text = readFileSync(abs, "utf8");
+  const records = kind === "lcov" ? parseLcov(text) : parseCobertura(text);
+  const unresolved = records.filter((r) => !existsSync(resolve(ROOT, r.file)));
+
+  const totalLines = records.reduce((a, r) => a + r.total, 0);
+  const coveredLines = records.reduce((a, r) => a + r.covered, 0);
+
+  const status = unresolved.length === 0 ? `${GREEN}✓${NC}` : `${RED}✗${NC}`;
+  console.log(
+    `${status} ${BOLD}${path}${NC} ${DIM}(${kind})${NC} — ${records.length} files, ` +
+      `${pct(coveredLines, totalLines)} lines, ` +
+      `${unresolved.length === 0 ? `${GREEN}all paths resolve${NC}` : `${RED}${unresolved.length} unresolved${NC}`}`
+  );
+
+  if (unresolved.length > 0) {
+    problems += unresolved.length;
+    for (const r of unresolved.slice(0, 10)) {
+      console.log(
+        `    ${RED}unresolved${NC} ${r.file} ${DIM}→ ${resolve(ROOT, r.file)} (not on disk)${NC}`
+      );
+    }
+    if (unresolved.length > 10) console.log(`    ${DIM}…and ${unresolved.length - 10} more${NC}`);
+    console.log(
+      `    ${YELLOW}Sonar will report these files as 0% coverage on new code.${NC}`
+    );
+  }
+}
+
+console.log("");
+if (missingReports > 0) {
+  console.log(
+    `${YELLOW}${missingReports} report(s) missing — generate them with ${BOLD}pnpm test:coverage${NC}${YELLOW} and re-run.${NC}`
+  );
+}
+if (problems > 0) {
+  console.log(
+    `${RED}${BOLD}FAIL${NC} ${problems} coverage path(s) won't resolve in SonarCloud (they'd show as 0%).`
+  );
+  process.exit(1);
+}
+if (missingReports > 0) {
+  process.exit(1);
+}
+console.log(`${GREEN}${BOLD}OK${NC} every coverage path resolves to a real file — SonarCloud will map it.`);

--- a/scripts/sonar-local.sh
+++ b/scripts/sonar-local.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Reproduce the SonarCloud coverage check locally before opening a PR.
+#
+# CI computes coverage in the Next.js + Python workflows, then a separate
+# SonarQube workflow downloads those reports and scans. The scan can silently
+# under-report: if a report's file paths don't resolve against the repo root,
+# Sonar drops that coverage and shows 0% on new code (no error). This script
+# regenerates the exact reports listed in sonar-project.properties and verifies
+# they map onto real files — catching that class of failure locally.
+#
+# Usage:
+#   scripts/sonar-local.sh            # generate coverage + verify paths
+#   scripts/sonar-local.sh --no-tests # verify existing reports only (fast)
+#   scripts/sonar-local.sh --scan     # also run the real scanner (needs SONAR_TOKEN)
+#
+# Exit non-zero if any coverage path won't resolve in SonarCloud.
+
+set -o pipefail
+cd "$(dirname "$0")/.." || exit 1
+
+RUN_TESTS=1
+RUN_SCAN=0
+for arg in "$@"; do
+  case "$arg" in
+    --no-tests) RUN_TESTS=0 ;;
+    --scan) RUN_SCAN=1 ;;
+    *) echo "unknown arg: $arg" >&2; exit 2 ;;
+  esac
+done
+
+if [ "$RUN_TESTS" -eq 1 ]; then
+  echo "━━━ Generating coverage (web + api + worker) ━━━"
+  # Mirrors the CI targets that feed Sonar. The web target reroots its lcov so
+  # paths are repo-root relative (see scripts/lcov-reroot.mjs).
+  pnpm nx run-many -t test:coverage --projects=web,api,worker || exit 1
+fi
+
+echo ""
+echo "━━━ Verifying coverage report paths resolve (the SonarCloud mapping) ━━━"
+node scripts/sonar-coverage-check.mjs || exit 1
+
+if [ "$RUN_SCAN" -eq 1 ]; then
+  echo ""
+  echo "━━━ Running the real SonarCloud scan ━━━"
+  if [ -z "${SONAR_TOKEN:-}" ]; then
+    echo "SONAR_TOKEN not set — skipping the live scan." >&2
+    echo "Export a token (Sonar > My Account > Security) and re-run with --scan." >&2
+    exit 1
+  fi
+  pnpm sonar -Dsonar.token="$SONAR_TOKEN" || exit 1
+fi


### PR DESCRIPTION
## Summary

- **Web files showed 0% in SonarCloud despite being well-tested.** Root cause: jest emits lcov paths relative to `apps/web` (`SF:src/...`), but SonarCloud resolves coverage paths against the **repo root**, so every web path matched nothing and the coverage was silently dropped (no error — just 0% on new code). Fixed by rerooting the lcov to repo-root-relative paths via `scripts/lcov-reroot.mjs`, wired into the web `test:coverage` target. This recovers coverage for `price-history.ts`, `access-denied/page.tsx`, `trip-row-actions.tsx`, and `trips/[tripId]/page.tsx` (all already exercised by existing tests — local lcov: 97.5% lines).
- **Closed the genuine Python gaps in `admin.py`** (was 83.5%): added tests for client-IP header precedence, rate-limit window expiry, invalid-JSON body, DB timeout/read-only error mapping, and the lazy admin-session factory; marked the Postgres-only `SET TRANSACTION READ ONLY` guard `# pragma: no cover`. `admin.py` is now **100%**. (`errors.py` was already 100% locally — its stale 92.3% clears on a fresh scan.)
- **Added a local SonarCloud coverage check** so this class of bug is caught before a PR: `pnpm sonar:verify` regenerates the exact reports CI feeds Sonar and fails if any report path won't resolve in SonarCloud; `pnpm sonar:check` validates existing reports; `--scan` runs the real scanner when `SONAR_TOKEN` is set.

## Test plan

- [x] `pnpm sonar:check` — all three reports resolve (web 97.5%, api 95.3%, worker 98.8% lines); fed an un-rerooted lcov and confirmed it flags the 41 web files as unresolved and exits non-zero.
- [x] `apps/api` coverage gate green — **96.06%** total, `admin.py` 100%, full suite 1119 passed.
- [x] `web:test:coverage` green via Nx; lcov rerooted to `apps/web/src/...` (41 paths prefixed).
- [x] `ruff` clean on changed Python; `pnpm verify` web + api pass (the lone failure is the pre-existing `pytest-randomly` ordering flake in worker tests — no worker files are in this diff; the worker suite passes deterministically with `-p no:randomly`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VoGSRWAmfDUbq1gkWSDFPX

---
_Generated by [Claude Code](https://claude.ai/code/session_01VoGSRWAmfDUbq1gkWSDFPX)_