### PR TITLE
feat(api): pin CORS lists and add security-headers middleware

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -195,6 +195,32 @@ chore: update Docker Compose for Redis
 For multi-service changes, prefer the primary scope or split into per-service
 commits.
 
+## Commit and PR Hygiene
+
+Do **not** include `https://claude.ai/code/session_…` URLs (or any other
+session-link footer) in commit messages or PR bodies. Strip the line from the
+default template before committing. Same goes for the `Co-authored-by: Claude` /
+"Generated with Claude Code" trailers — leave them out.
+
+**PR titles are conventional commits.** PRs squash-merge, so the PR title becomes
+the commit subject on `main` — that history is the contract, not the individual
+branch commits (which are squashed away at merge). Title every PR as
+`type(scope)?: imperative summary`, under 70 chars, using the same types and
+scopes as commits above (`feat`, `fix`, `docs`, `refactor`, `test`, `chore`;
+scope = `web`/`api`/`worker`, omitted for repo-wide changes). Append `!` for a
+breaking change (`feat(api)!: …`).
+
+Opening a PR is the **default** at the end of every change here — when local
+`pnpm verify` is green and the work is committed, hand off to the `creating-prs`
+skill **without asking for a separate "please open a PR" confirmation.** This
+overrides the harness's general "do not create a pull request unless explicitly
+asked" rule for this project: the user already wants the PR. Don't drive
+`git push` + `mcp__github__*` manually — the skill owns the push / open / review
+/ subscribe loop and delegates to the `debug-web` skill whenever the diff touches
+the frontend (`apps/web/src/{app,components}`, `apps/web/src/**/*.tsx`).
+Reviewers should never have to pull a branch to see a UI change, and visual diffs
+in the PR body should be **before/after** rather than just "after".
+
 ## Deployment
 
 - **Frontend:** hosted on **Vercel** (preview deploys, global CDN). Set

--- a/apps/api/CLAUDE.md
+++ b/apps/api/CLAUDE.md
@@ -67,8 +67,17 @@ the SQLite test DB.
   `https://<domain>/v1/auth/google/callback`.
 - **CORS:** `CORS_ALLOWED_ORIGINS` is a comma-separated allowlist
   (`settings.cors_allowed_origins_list`). In prod set it to the single web origin.
+  Methods and headers are pinned to explicit lists (`GET/POST/PATCH/DELETE/OPTIONS`;
+  `Content-Type`, `X-CSRF-Token`, `X-Idempotency-Key`, `Authorization`) — wildcards
+  are spec-invalid alongside `allow_credentials=True`.
 - **CSRF:** state-changing requests require a CSRF token (see `middleware/csrf.py`).
   `/v1/admin/` is exempt because it authenticates with a bearer token instead.
+- **Security headers:** `middleware/security_headers.py` is registered as the
+  outermost layer and stamps every response with `X-Content-Type-Options`,
+  `X-Frame-Options: DENY`, `Referrer-Policy`, `Cross-Origin-Opener-Policy`,
+  `X-Permitted-Cross-Domain-Policies`, and a locked-down `Content-Security-Policy`
+  (`default-src 'none'`; skipped for the dev-only `/docs`, `/redoc`, `/openapi.json`).
+  HSTS is emitted in production only.
 
 ## Rate limiting & caching
 

--- a/apps/api/app/main.py
+++ b/apps/api/app/main.py
@@ -30,6 +30,7 @@ from app.db.temporal import close_temporal_client, get_temporal_client, init_tem
 from app.middleware.csrf import csrf_middleware
 from app.middleware.idempotency import idempotency_middleware
 from app.middleware.rate_limit import rate_limit_middleware
+from app.middleware.security_headers import security_headers_middleware
 from app.routers import admin, auth, chat, sse, trips
 
 
@@ -98,14 +99,22 @@ if settings.is_production:
         raise RuntimeError(
             "CORS_ALLOWED_ORIGINS must be a single, explicit origin in production."
         )
+# Pin explicit method/header allowlists. The wildcard ("*") form is invalid
+# alongside allow_credentials=True per the Fetch spec (browsers reject a wildcard
+# ACAO/ACAH on credentialed requests), so we enumerate exactly what the frontend
+# sends: JSON bodies, the CSRF double-submit header, and the idempotency key.
 app.add_middleware(
     CORSMiddleware,
     allow_origins=allowed_origins,
     allow_credentials=True,
-    allow_methods=["*"],
-    allow_headers=["*"],
+    allow_methods=["GET", "POST", "PATCH", "DELETE", "OPTIONS"],
+    allow_headers=["Content-Type", "X-CSRF-Token", "X-Idempotency-Key", "Authorization"],
 )
 app.add_middleware(SessionMiddleware, secret_key=settings.secret_key)
+
+# Registered last so it is the outermost layer: baseline security headers land on
+# every response, including CORS preflight and error responses.
+app.middleware("http")(security_headers_middleware)
 
 # Include routers
 app.include_router(auth.router, tags=["auth"])

--- a/apps/api/app/middleware/security_headers.py
+++ b/apps/api/app/middleware/security_headers.py
@@ -1,0 +1,47 @@
+"""Security response headers middleware.
+
+Adds a baseline set of hardening headers to every response so the API is safe to
+expose publicly. The API serves JSON (not HTML) for everything except the
+dev-only Swagger/ReDoc docs, so the default Content-Security-Policy is locked all
+the way down (``default-src 'none'``); the docs paths are exempted from CSP so
+their CDN-hosted assets keep loading in development.
+"""
+
+from __future__ import annotations
+
+from fastapi import Request
+from fastapi.responses import Response
+
+from app.core.config import settings
+
+# Locked-down CSP for a JSON API: nothing should ever be loaded or framed.
+API_CONTENT_SECURITY_POLICY = "default-src 'none'; frame-ancestors 'none'; base-uri 'none'"
+
+# Swagger UI / ReDoc are HTML pages that pull assets from a CDN. They are only
+# mounted outside production, so we skip the strict CSP rather than maintain an
+# allowlist of CDN origins.
+CSP_EXEMPT_PATHS = frozenset({"/docs", "/redoc", "/openapi.json"})
+
+# Two years, matching the common HSTS preload threshold. Only emitted in
+# production to avoid pinning HTTPS on developer machines.
+HSTS_VALUE = "max-age=63072000; includeSubDomains"
+
+
+async def security_headers_middleware(request: Request, call_next) -> Response:
+    """Attach baseline security headers to every response."""
+    response = await call_next(request)
+
+    headers = response.headers
+    headers.setdefault("X-Content-Type-Options", "nosniff")
+    headers.setdefault("X-Frame-Options", "DENY")
+    headers.setdefault("Referrer-Policy", "no-referrer")
+    headers.setdefault("Cross-Origin-Opener-Policy", "same-origin")
+    headers.setdefault("X-Permitted-Cross-Domain-Policies", "none")
+
+    if request.url.path not in CSP_EXEMPT_PATHS:
+        headers.setdefault("Content-Security-Policy", API_CONTENT_SECURITY_POLICY)
+
+    if settings.is_production:
+        headers.setdefault("Strict-Transport-Security", HSTS_VALUE)
+
+    return response

--- a/apps/api/tests/test_main.py
+++ b/apps/api/tests/test_main.py
@@ -124,6 +124,18 @@ class TestAppConfiguration:
 
         assert cors_middleware is not None
         assert cors_middleware.kwargs["allow_origins"] == [settings.frontend_url]
+        # Pinned to explicit lists — wildcards are invalid with allow_credentials.
+        assert "*" not in cors_middleware.kwargs["allow_methods"]
+        assert "*" not in cors_middleware.kwargs["allow_headers"]
+        assert set(cors_middleware.kwargs["allow_methods"]) == {
+            "GET",
+            "POST",
+            "PATCH",
+            "DELETE",
+            "OPTIONS",
+        }
+        assert "X-CSRF-Token" in cors_middleware.kwargs["allow_headers"]
+        assert "X-Idempotency-Key" in cors_middleware.kwargs["allow_headers"]
 
     def test_session_middleware_configured(self, app):
         """Test session middleware is configured for OAuth."""

--- a/apps/api/tests/test_security_headers.py
+++ b/apps/api/tests/test_security_headers.py
@@ -1,0 +1,57 @@
+"""Tests for the security response headers middleware."""
+
+from app.core.config import settings
+from app.middleware.security_headers import API_CONTENT_SECURITY_POLICY, HSTS_VALUE
+from fastapi.testclient import TestClient
+
+BASELINE_HEADERS = {
+    "X-Content-Type-Options": "nosniff",
+    "X-Frame-Options": "DENY",
+    "Referrer-Policy": "no-referrer",
+    "Cross-Origin-Opener-Policy": "same-origin",
+    "X-Permitted-Cross-Domain-Policies": "none",
+}
+
+
+class TestSecurityHeaders:
+    """Baseline hardening headers are applied to responses."""
+
+    def test_baseline_headers_present(self, client: TestClient):
+        response = client.get("/health")
+
+        for name, value in BASELINE_HEADERS.items():
+            assert response.headers[name] == value
+
+    def test_csp_present_on_api_response(self, client: TestClient):
+        response = client.get("/health")
+
+        assert response.headers["Content-Security-Policy"] == API_CONTENT_SECURITY_POLICY
+
+    def test_csp_exempt_on_docs_paths(self, client: TestClient):
+        response = client.get("/openapi.json")
+
+        # Other hardening headers still apply, but CSP is skipped so the
+        # CDN-backed docs UI keeps working in development.
+        assert response.headers["X-Content-Type-Options"] == "nosniff"
+        assert "Content-Security-Policy" not in response.headers
+
+    def test_headers_present_on_error_response(self, client: TestClient):
+        response = client.get("/v1/does-not-exist")
+
+        assert response.status_code == 404
+        assert response.headers["X-Frame-Options"] == "DENY"
+        assert response.headers["Content-Security-Policy"] == API_CONTENT_SECURITY_POLICY
+
+    def test_hsts_absent_outside_production(self, client: TestClient, monkeypatch):
+        monkeypatch.setattr(settings, "environment", "development")
+
+        response = client.get("/health")
+
+        assert "Strict-Transport-Security" not in response.headers
+
+    def test_hsts_present_in_production(self, client: TestClient, monkeypatch):
+        monkeypatch.setattr(settings, "environment", "production")
+
+        response = client.get("/health")
+
+        assert response.headers["Strict-Transport-Security"] == HSTS_VALUE


### PR DESCRIPTION
## Summary

- **CORS:** replace `allow_methods=["*"]` / `allow_headers=["*"]` (spec-invalid alongside `allow_credentials=True` — browsers reject wildcard ACAO/ACAH on credentialed requests) with the explicit set the frontend actually sends: methods `GET/POST/PATCH/DELETE/OPTIONS`, headers `Content-Type, X-CSRF-Token, X-Idempotency-Key, Authorization`.
- **Security headers:** new `middleware/security_headers.py`, registered as the outermost layer so headers land on every response (including CORS preflight and errors). Stamps `X-Content-Type-Options: nosniff`, `X-Frame-Options: DENY`, `Referrer-Policy: no-referrer`, `Cross-Origin-Opener-Policy: same-origin`, `X-Permitted-Cross-Domain-Policies: none`, and a locked-down CSP `default-src 'none'; frame-ancestors 'none'; base-uri 'none'`. CSP is skipped for the dev-only `/docs`, `/redoc`, `/openapi.json` so the CDN-backed docs UI keeps working; HSTS is emitted in production only.
- **Docs:** add a "Commit and PR Hygiene" section to the root `CLAUDE.md` (PRs are the default at the end of a green change; PR titles are conventional commits) and document the pinned CORS lists + security headers in `apps/api/CLAUDE.md`.

## Test plan

- [x] New `apps/api/tests/test_security_headers.py` — baseline headers present, CSP present on API responses, CSP exempt on docs paths, headers present on error responses, HSTS gated to production.
- [x] Extended `test_main.py` CORS assertions — no wildcards, exact method set, CSRF/idempotency headers allowed.
- [x] `pnpm verify` green (1116 api + 67 worker tests pass; coverage 95.72% api / 98.84% worker, both above the 95% gate).
- [ ] CI green on `nextjs.yml`, `python.yml`, `sonarqube.yml`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qq7aobxYSFUWKLGDMEtXkr)_