### PR TITLE
test(worker): isolate activity tests from ambient MOCK_SKIPLAGGED_API

### DIFF
--- a/apps/worker/tests/conftest.py
+++ b/apps/worker/tests/conftest.py
@@ -4,6 +4,8 @@ import os
 import sys
 from pathlib import Path
 
+import pytest
+
 # Disable Langfuse telemetry for tests — must happen BEFORE any `app.*` import.
 os.environ["LANGFUSE_PUBLIC_KEY"] = ""
 os.environ["LANGFUSE_SECRET_KEY"] = ""
@@ -11,3 +13,22 @@ os.environ["LANGFUSE_SECRET_KEY"] = ""
 WORKER_ROOT = Path(__file__).resolve().parents[1]
 if str(WORKER_ROOT) not in sys.path:
     sys.path.insert(0, str(WORKER_ROOT))
+
+
+@pytest.fixture(autouse=True)
+def _real_skiplagged_by_default(monkeypatch):
+    """Pin ``mock_skiplagged_api`` off so the activity tests are deterministic
+    regardless of the ambient ``MOCK_SKIPLAGGED_API``.
+
+    The dev ``.env`` sets ``MOCK_SKIPLAGGED_API=true``, and Nx's ``run-commands``
+    auto-loads ``.env`` — so ``pnpm verify`` / ``pnpm nx run worker:test:coverage``
+    ran the activities down the *mock* branch, where the tests' patched
+    ``SkiplaggedClient`` is never called (CI was green only because its fresh
+    checkout has no ``.env``). Defaulting the flag off here makes the suite pass
+    whether or not a ``.env`` is present; tests that exercise mock mode opt back
+    in with their own ``monkeypatch.setattr(..., "mock_skiplagged_api", True)``,
+    which runs after this fixture and wins.
+    """
+    from app.core.config import settings
+
+    monkeypatch.setattr(settings, "mock_skiplagged_api", False)


### PR DESCRIPTION
## Summary

- Four tests in `test_price_check_activities.py` failed under `pnpm verify` / `pnpm nx run worker:test:coverage` locally (`search_flights_all` "called 0 times", hotel detail counts `0 == 20`), yet passed under a bare `uv run pytest` and in CI.
- **Root cause:** Nx's `run-commands` auto-loads the repo `.env`, which in dev sets `MOCK_SKIPLAGGED_API=true`. That routes `fetch_flights_activity` / `fetch_hotels_activity` down the **mock** branch, so the tests' patched `SkiplaggedClient` is never invoked. CI stays green only because its fresh checkout has no `.env`. It was **not** flakiness/random ordering — there's no `pytest-randomly` installed; the trigger is purely the ambient env var.
- **Fix:** an autouse fixture in the worker `conftest.py` pins `mock_skiplagged_api` **off** by default, making the suite deterministic with or without a `.env`. Tests that exercise mock mode still opt in via their own `monkeypatch.setattr(..., True)`, which runs after the fixture and wins. No production code changes.

## Test plan

- [x] `pnpm nx run worker:test:coverage` (loads `.env`, `MOCK_SKIPLAGGED_API=true`) — **71 passed**, coverage 98.86% (gate ≥95%).
- [x] `uv run pytest apps/worker/tests` with `MOCK_SKIPLAGGED_API=true` and unset — **71 passed** both ways (previously 4 failed when the flag was on).
- [x] `--collect-only` confirms the fixture changes no test collection (71/73, 2 integration deselected) — it only pins the setting.
- [x] `ruff check apps/worker/tests/conftest.py` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VoGSRWAmfDUbq1gkWSDFPX

---
_Generated by [Claude Code](https://claude.ai/code/session_01VoGSRWAmfDUbq1gkWSDFPX)_