### PR TITLE
fix(api): scrub client telemetry strings before logging (CWE-117)

### DIFF
--- a/apps/api/app/routers/telemetry.py
+++ b/apps/api/app/routers/telemetry.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 
 import jwt
 from fastapi import APIRouter, Request
@@ -28,6 +29,19 @@ router = APIRouter(prefix="/v1/telemetry", tags=["telemetry"])
 logger = logging.getLogger("app.web.telemetry")
 
 MAX_CONTEXT_BYTES = 8 * 1024
+
+# Control characters (CR/LF, tabs, terminal escapes, …). Client-supplied strings
+# are scrubbed of these before they reach the logger so a crafted value can't
+# forge extra log records or smuggle escape sequences into the log/Axiom pipeline
+# (CWE-117, log injection).
+_LOG_CONTROL_CHARS = re.compile(r"[\x00-\x1f\x7f-\x9f]")
+
+
+def _scrub_for_log(value: str) -> str:
+    """Neutralize untrusted text for logging by stripping line breaks and other
+    control characters. Newlines are removed explicitly (the injection vector);
+    the regex catches the remaining control range."""
+    return _LOG_CONTROL_CHARS.sub(" ", value.replace("\r", " ").replace("\n", " "))
 
 # Allowlist of context keys promoted to structured log fields. Unknown keys are
 # dropped (and counted) so an unauthenticated caller can't bloat the log surface.
@@ -94,15 +108,19 @@ def _user_id_from_cookie(request: Request) -> str | None:
 async def log_client_event(payload: ClientEvent, request: Request) -> dict:
     """Relay a browser telemetry event into the shared Axiom pipeline."""
     safe = _sanitize_context(payload.context)
+    # Scrub the client-controlled strings of control characters before they reach
+    # the logger (CWE-117). `message` is the log message; `event` is interpolated
+    # into a structured field — both originate from the untrusted request body.
+    safe_message = _scrub_for_log(payload.message)
     # Server-controlled fields win — a client must not forge event/user_id.
     extra = {
         **safe,
-        "event": f"web.{payload.event}",
+        "event": f"web.{_scrub_for_log(payload.event)}",
         "component": "web.telemetry",
         "user_id": _user_id_from_cookie(request),
     }
     if payload.level == "warn":
-        logger.warning(payload.message, extra=extra)
+        logger.warning(safe_message, extra=extra)
     else:
-        logger.error(payload.message, extra=extra)
+        logger.error(safe_message, extra=extra)
     return {"ok": True}

--- a/apps/api/tests/routers/test_telemetry.py
+++ b/apps/api/tests/routers/test_telemetry.py
@@ -100,3 +100,24 @@ def test_no_context_is_fine(client, caplog):
     with caplog.at_level(logging.ERROR, logger="app.web.telemetry"):
         resp = client.post(URL, json={"event": "x", "message": "m", "context": None})
     assert resp.status_code == 200
+
+
+def test_message_and_event_are_scrubbed_of_control_chars(client, caplog):
+    """CR/LF (and other control chars) in client-controlled fields are stripped
+    before logging, so a crafted payload can't forge extra log lines (CWE-117)."""
+    with caplog.at_level(logging.ERROR, logger="app.web.telemetry"):
+        resp = client.post(
+            URL,
+            json={
+                "event": "trip\r\nadmin.spoof",
+                "message": "real\nINJECTED fake log line\ttabbed",
+            },
+        )
+    assert resp.status_code == 200
+    record = caplog.records[-1]
+    # No raw line breaks survive in either the message or the server-set event.
+    assert "\n" not in record.getMessage()
+    assert "\r" not in record.getMessage()
+    assert "\n" not in record.event and "\r" not in record.event
+    assert record.event == "web.trip  admin.spoof"
+    assert record.getMessage() == "real INJECTED fake log line tabbed"


### PR DESCRIPTION
## Summary

The SonarCloud quality gate failed on the last merge to `main` — **Security Rating on New Code = B** (requires ≥ A), from two log-injection vulnerabilities (`python:S5145`, CWE-117) in `apps/api/app/routers/telemetry.py`:

- The unauthenticated `POST /v1/telemetry/client` relay logged the client-controlled `message` directly as the log message (L105/L107) and interpolated the client-controlled `event` into a structured field. A crafted payload containing `\r\n` could **forge extra log records** or smuggle terminal escapes into the stdout → Axiom pipeline.

**Fix:** scrub both client-controlled strings of line breaks and other control characters before they reach the logger — newlines removed explicitly (the injection vector), plus a control-range regex for the rest. Server-set fields (`component`, `user_id`) and the context allowlist are unchanged. This follows SonarSource's documented S5145 remediation.

> Note: this is a *security-rating* condition, a different quality-gate dimension than the coverage condition fixed in #17 — that fix held. See the PR thread / my message to the user for why the local `pnpm sonar:verify` (a coverage-path check) couldn't catch a security finding, and the tooling follow-up.

## Test plan

- [x] `apps/api` coverage gate green — **96.02%** total; `telemetry.py` **100%** (54/54).
- [x] New test asserts `\r`, `\n`, and `\t` are stripped from both `message` and the server-set `event` (`web.trip  admin.spoof`), so no raw line break survives in `record.getMessage()` / `record.event`.
- [x] Existing telemetry relay tests (allowlist, event/user_id non-forgeability, cookie user-id, clipping) still pass — 10 passed.
- [x] `ruff` clean.
- [ ] **Definitive confirmation is the post-merge SonarCloud scan** — the Security Rating is computed server-side and can't be reproduced locally without a `SONAR_TOKEN` (this is the tooling gap I'm addressing separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VoGSRWAmfDUbq1gkWSDFPX

---
_Generated by [Claude Code](https://claude.ai/code/session_01VoGSRWAmfDUbq1gkWSDFPX)_