### PR TITLE
chore: make pnpm sonar:verify reproduce the full quality gate

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -201,24 +201,34 @@ Playwright (requires the Docker stack up).
 
 Coverage gates: **95%** for both Python apps (`api`, `worker`).
 
-### SonarCloud coverage (run locally before a PR)
+### SonarCloud quality gate (run locally before a PR)
 
 CI computes coverage in the Next.js + Python workflows, then a **separate**
 SonarQube workflow downloads those reports and scans (`sonar-project.properties`).
-That scan can under-report **silently**: SonarCloud resolves every path in a
-coverage report against the repo root, and any path that doesn't resolve is
-dropped and shown as **0% on new code** with no error (this is exactly how jest's
-`SF:src/...` lcov paths — relative to `apps/web` — vanished). To catch it before
-pushing:
+The gate has **several conditions** — Coverage, **Security Rating**, Reliability,
+Maintainability, Duplications — and a PR can fail on any of them.
 
-- **`pnpm sonar:verify`** — regenerates the same reports CI feeds Sonar
-  (`test:coverage` for web/api/worker) and checks every path resolves to a real
-  file. `--no-tests` validates existing reports only; `--scan` also runs the real
-  scanner (needs `SONAR_TOKEN`).
-- **`pnpm sonar:check`** — just the path/coverage validator over existing reports.
+**Two levels of local check** (`scripts/sonar-local.sh`):
+
+- **`pnpm sonar:verify`** (no token) — regenerates the same reports CI feeds Sonar
+  and checks every path resolves to a real file. This covers the **Coverage
+  dimension only**: SonarCloud resolves report paths against the repo root, and a
+  path that doesn't resolve is silently dropped and shown as **0% on new code**
+  (this is exactly how jest's `SF:src/...` paths, relative to `apps/web`,
+  vanished). `--no-tests` validates existing reports only. **It does NOT evaluate
+  the Security/Reliability/Maintainability ratings** — those are computed by
+  Sonar's rule engine, not from the coverage reports.
+- **`pnpm sonar:verify --scan`** (needs `SONAR_TOKEN`) — runs the **real scanner**
+  with `sonar.qualitygate.wait=true`, which uploads the analysis and blocks until
+  SonarCloud returns the gate verdict, failing on **any** condition (security
+  included). This is the only faithful local reproduction of the full gate.
+- **`pnpm sonar:check`** — just the coverage path validator over existing reports.
 
 The web `test:coverage` target reroots its lcov to repo-root-relative paths via
-`scripts/lcov-reroot.mjs`, so the report Sonar consumes always maps onto real files.
+`scripts/lcov-reroot.mjs`, so the report Sonar consumes always maps onto real
+files. **Heads-up:** a green `sonar:verify` only means coverage will map — a
+security finding (e.g. CWE-117 log injection: never log un-scrubbed client input)
+can still drop the gate. Use `--scan` to be sure.
 
 ## Verification Preference
 

--- a/scripts/sonar-coverage-check.mjs
+++ b/scripts/sonar-coverage-check.mjs
@@ -17,6 +17,13 @@
 //
 // Run AFTER generating coverage (`pnpm test:coverage`), or use the
 // `scripts/sonar-local.sh` wrapper which does both. No SONAR_TOKEN needed.
+//
+// SCOPE — this validates ONLY the *Coverage* quality-gate dimension. It does NOT
+// run SonarCloud's rule engine, so it cannot see the Security / Reliability /
+// Maintainability / Duplications ratings. A gate can still fail on those even
+// when this passes (e.g. a CWE-117 log-injection finding drops Security to B).
+// To reproduce the FULL gate locally, run `scripts/sonar-local.sh --scan` with a
+// SONAR_TOKEN — that uploads the real analysis and waits on the gate verdict.
 
 import { readFileSync, existsSync } from "node:fs";
 import { fileURLToPath } from "node:url";
@@ -32,10 +39,13 @@ const DIM = "\x1b[2m";
 const BOLD = "\x1b[1m";
 const NC = "\x1b[0m";
 
+/** Split on LF or CRLF so Windows-authored reports parse identically. */
+const splitLines = (text) => text.split(/\r?\n/);
+
 /** Parse sonar-project.properties into a flat key→value map (handles `\` line continuations). */
 function parseProps(text) {
   const out = {};
-  const lines = text.split("\n");
+  const lines = splitLines(text);
   for (let i = 0; i < lines.length; i++) {
     let line = lines[i];
     if (!line.trim() || line.trim().startsWith("#")) continue;
@@ -61,7 +71,7 @@ function parseLcov(text) {
   let file = null;
   let found = 0;
   let hit = 0;
-  for (const line of text.split("\n")) {
+  for (const line of splitLines(text)) {
     if (line.startsWith("SF:")) {
       file = line.slice(3).trim();
       found = 0;
@@ -78,9 +88,20 @@ function parseLcov(text) {
   return records;
 }
 
-/** Extract { file, total, covered } records from a Cobertura (coverage.py) XML report. */
+/**
+ * Extract { records, sources } from a Cobertura (coverage.py) XML report.
+ * `sources` are the <source> roots; a class filename may be relative to the
+ * repo root OR to one of these, so callers try both when resolving.
+ */
 function parseCobertura(text) {
   const records = [];
+  const sources = [];
+  const srcRe = /<source>([^<]*)<\/source>/g;
+  let sm;
+  while ((sm = srcRe.exec(text)) !== null) {
+    const s = sm[1].trim();
+    if (s) sources.push(s);
+  }
   const classRe = /<class\b[^>]*\bfilename="([^"]+)"[^>]*>([\s\S]*?)<\/class>/g;
   let m;
   while ((m = classRe.exec(text)) !== null) {
@@ -96,7 +117,7 @@ function parseCobertura(text) {
     }
     records.push({ file, total, covered });
   }
-  return records;
+  return { records, sources };
 }
 
 function pct(covered, total) {
@@ -130,8 +151,15 @@ for (const { path, kind } of reports) {
   }
 
   const text = readFileSync(abs, "utf8");
-  const records = kind === "lcov" ? parseLcov(text) : parseCobertura(text);
-  const unresolved = records.filter((r) => !existsSync(resolve(ROOT, r.file)));
+  const { records, sources } =
+    kind === "lcov" ? { records: parseLcov(text), sources: [] } : parseCobertura(text);
+
+  // Sonar resolves a coverage path against the project base dir (the repo root);
+  // for Cobertura it may also be relative to a declared <source> root. A record
+  // resolves if any of those candidates exists on disk.
+  const resolvesOnDisk = (file) =>
+    existsSync(resolve(ROOT, file)) || sources.some((s) => existsSync(resolve(ROOT, s, file)));
+  const unresolved = records.filter((r) => !resolvesOnDisk(r.file));
 
   const totalLines = records.reduce((a, r) => a + r.total, 0);
   const coveredLines = records.reduce((a, r) => a + r.covered, 0);
@@ -173,3 +201,7 @@ if (missingReports > 0) {
   process.exit(1);
 }
 console.log(`${GREEN}${BOLD}OK${NC} every coverage path resolves to a real file — SonarCloud will map it.`);
+console.log(
+  `${DIM}Note: this checks the Coverage dimension only. Security / Reliability /` +
+    ` Maintainability ratings are evaluated by the real scan (sonar-local.sh --scan).${NC}`
+);

--- a/scripts/sonar-local.sh
+++ b/scripts/sonar-local.sh
@@ -1,19 +1,28 @@
 #!/usr/bin/env bash
-# Reproduce the SonarCloud coverage check locally before opening a PR.
+# Reproduce the SonarCloud checks locally before opening a PR.
 #
 # CI computes coverage in the Next.js + Python workflows, then a separate
-# SonarQube workflow downloads those reports and scans. The scan can silently
-# under-report: if a report's file paths don't resolve against the repo root,
-# Sonar drops that coverage and shows 0% on new code (no error). This script
-# regenerates the exact reports listed in sonar-project.properties and verifies
-# they map onto real files — catching that class of failure locally.
+# SonarQube workflow downloads those reports and runs the scan that evaluates the
+# quality gate. The gate has SEVERAL conditions — Coverage, Security, Reliability,
+# Maintainability, Duplications. This script can reproduce them at two levels:
+#
+#   1. Coverage mapping (default, no token): regenerate the exact reports listed
+#      in sonar-project.properties and verify their paths resolve against the repo
+#      root, so Sonar maps coverage onto real files (a path mismatch silently
+#      shows 0% on new code). This is necessary but NOT the whole gate.
+#   2. Full gate (--scan, needs SONAR_TOKEN): run the real scanner with
+#      `sonar.qualitygate.wait=true`, which uploads the analysis and BLOCKS until
+#      SonarCloud returns the gate verdict — failing the command if ANY condition
+#      fails, including Security (e.g. a CWE-117 log-injection finding). This is
+#      the only faithful local reproduction of "did the gate pass".
 #
 # Usage:
-#   scripts/sonar-local.sh            # generate coverage + verify paths
+#   scripts/sonar-local.sh            # generate coverage + verify path mapping
 #   scripts/sonar-local.sh --no-tests # verify existing reports only (fast)
-#   scripts/sonar-local.sh --scan     # also run the real scanner (needs SONAR_TOKEN)
+#   scripts/sonar-local.sh --scan     # also run the real scanner + wait on the gate
 #
-# Exit non-zero if any coverage path won't resolve in SonarCloud.
+# Exit non-zero if a coverage path won't resolve, a test target failed, or (with
+# --scan) the quality gate fails.
 
 set -o pipefail
 cd "$(dirname "$0")/.." || exit 1
@@ -28,24 +37,60 @@ for arg in "$@"; do
   esac
 done
 
+tests_status=0
 if [ "$RUN_TESTS" -eq 1 ]; then
   echo "━━━ Generating coverage (web + api + worker) ━━━"
   # Mirrors the CI targets that feed Sonar. The web target reroots its lcov so
   # paths are repo-root relative (see scripts/lcov-reroot.mjs).
-  pnpm nx run-many -t test:coverage --projects=web,api,worker || exit 1
+  #
+  # We do NOT abort on a non-zero exit here: a failing/flaky test target still
+  # writes its coverage report, and the report-path validation below is the
+  # unique job of this script — it must run regardless so a single red suite
+  # doesn't mask a Sonar path-resolution regression. The failure is surfaced in
+  # the final summary and folded into the exit code.
+  pnpm nx run-many -t test:coverage --projects=web,api,worker || tests_status=$?
+  [ "$tests_status" -ne 0 ] && echo "⚠ coverage generation reported failures (see above) — continuing to the path check"
 fi
 
 echo ""
 echo "━━━ Verifying coverage report paths resolve (the SonarCloud mapping) ━━━"
-node scripts/sonar-coverage-check.mjs || exit 1
+check_status=0
+node scripts/sonar-coverage-check.mjs || check_status=$?
 
+scan_status=0
 if [ "$RUN_SCAN" -eq 1 ]; then
   echo ""
-  echo "━━━ Running the real SonarCloud scan ━━━"
+  echo "━━━ Running the real SonarCloud scan + waiting on the quality gate ━━━"
   if [ -z "${SONAR_TOKEN:-}" ]; then
-    echo "SONAR_TOKEN not set — skipping the live scan." >&2
+    echo "SONAR_TOKEN not set — cannot run the live scan." >&2
     echo "Export a token (Sonar > My Account > Security) and re-run with --scan." >&2
     exit 1
   fi
-  pnpm sonar -Dsonar.token="$SONAR_TOKEN" || exit 1
+  # qualitygate.wait makes the scanner poll SonarCloud and exit non-zero if the
+  # gate fails on ANY condition — coverage AND security/reliability/maintainability.
+  pnpm sonar -Dsonar.token="$SONAR_TOKEN" -Dsonar.qualitygate.wait=true || scan_status=$?
 fi
+
+echo ""
+echo "━━━ Summary ━━━"
+if [ "$check_status" -eq 0 ]; then
+  echo "✓ Coverage path check passed — coverage will map onto real files."
+else
+  echo "✗ Coverage path check FAILED — some coverage would report as 0% (see above)."
+fi
+if [ "$tests_status" -ne 0 ]; then
+  echo "✗ Coverage generation had test failures — reports may be stale; fix the suite for trustworthy numbers."
+fi
+if [ "$RUN_SCAN" -eq 1 ]; then
+  if [ "$scan_status" -eq 0 ]; then
+    echo "✓ SonarCloud quality gate PASSED (all conditions, security included)."
+  else
+    echo "✗ SonarCloud quality gate FAILED — see the project dashboard for the failing condition(s)."
+  fi
+else
+  echo "ℹ Coverage dimension only. The Security / Reliability / Maintainability ratings"
+  echo "  were NOT evaluated — re-run with --scan (and a SONAR_TOKEN) for the full gate."
+fi
+
+# Fail if the path check failed, a test target failed, or the gate failed.
+[ "$check_status" -eq 0 ] && [ "$tests_status" -eq 0 ] && [ "$scan_status" -eq 0 ]


### PR DESCRIPTION
## Summary

Answers "why didn't the local sonar tooling catch the security-rating failure?" — and closes the gap.

**Why it didn't catch it:** `pnpm sonar:verify` / `sonar-coverage-check.mjs` (added in #17) validate exactly **one** quality-gate dimension — *Coverage*. They check that coverage report paths resolve so SonarCloud maps them onto files. They never run Sonar's rule engine, so they have **zero visibility** into the Security / Reliability / Maintainability ratings. The gate that broke was **Security Rating on New Code** (a CWE-117 log-injection finding), which is computed server-side — completely outside what the tool inspects. It was necessary-but-not-sufficient and read as "gate is fine."

**The fix — make `--scan` reproduce the *whole* gate:**

- `scripts/sonar-local.sh --scan` now runs the real scanner with **`sonar.qualitygate.wait=true`**, which uploads the analysis and **blocks until SonarCloud returns the gate verdict**, failing on *any* condition (security included). That's the only faithful local reproduction of "did the gate pass." The default (no-token) run now states loudly it covered the *Coverage dimension only*.
- Decouple the path check from test-target failures — a flaky/red suite still writes its report, and the path check is the script's unique job, so it must run regardless; both signals are reported in a summary.
- `sonar-coverage-check.mjs`: scope banner, CRLF-safe parsing, and `<source>`-aware Cobertura resolution (the earlier peer-review nits, which never landed).
- `CLAUDE.md`: documents the two levels and that **a green `sonar:verify` ≠ a green gate**.

## Test plan

- [x] `node -c` / `bash -n` syntax-clean; `pnpm sonar:check` runs green with the new scope note (web 97.5%, api 96.1%, worker 98.9%, all paths resolve).
- [x] Decoupling verified earlier in-session: with a failing worker target, the path check still runs and the summary reports both signals; exit code folds in test + check + scan status.
- [x] No production code touched (scripts + docs only).
- [ ] `--scan` path needs a `SONAR_TOKEN` to exercise end-to-end (not available in the sandbox) — the `qualitygate.wait` flag is the documented SonarSource mechanism.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VoGSRWAmfDUbq1gkWSDFPX

---
_Generated by [Claude Code](https://claude.ai/code/session_01VoGSRWAmfDUbq1gkWSDFPX)_