### PR TITLE
fix: exclude un-measured sources from Sonar coverage analysis

### DIFF
--- a/.github/workflows/nextjs.yml
+++ b/.github/workflows/nextjs.yml
@@ -10,6 +10,7 @@ on:
       - "nx.json"
       - "tsconfig*.json"
       - ".github/workflows/nextjs.yml"
+      - "sonar-project.properties"
   pull_request:
     branches: [main]
     paths:
@@ -19,6 +20,7 @@ on:
       - "nx.json"
       - "tsconfig*.json"
       - ".github/workflows/nextjs.yml"
+      - "sonar-project.properties"
 
 # Cancel superseded runs on a PR; let main builds finish.
 concurrency:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -13,6 +13,7 @@ on:
       - "pnpm-lock.yaml"
       - "nx.json"
       - ".github/workflows/python.yml"
+      - "sonar-project.properties"
   pull_request:
     branches: [main]
     paths:
@@ -25,6 +26,7 @@ on:
       - "pnpm-lock.yaml"
       - "nx.json"
       - ".github/workflows/python.yml"
+      - "sonar-project.properties"
 
 concurrency:
   group: python-${{ github.ref }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -213,13 +213,17 @@ Maintainability, Duplications — and a PR can fail on any of them.
 **Two levels of local check** (`scripts/sonar-local.sh`):
 
 - **`pnpm sonar:verify`** (no token) — regenerates the same reports CI feeds Sonar
-  and checks every path resolves to a real file. This covers the **Coverage
-  dimension only**: SonarCloud resolves report paths against the repo root, and a
-  path that doesn't resolve is silently dropped and shown as **0% on new code**
-  (this is exactly how jest's `SF:src/...` paths, relative to `apps/web`,
-  vanished). `--no-tests` validates existing reports only. **It does NOT evaluate
-  the Security/Reliability/Maintainability ratings** — those are computed by
-  Sonar's rule engine, not from the coverage reports.
+  and checks the **Coverage dimension** two ways: (1) every report path resolves
+  against the repo root (a path that doesn't is silently dropped and shown as **0%
+  on new code** — exactly how jest's `SF:src/...` paths, relative to `apps/web`,
+  vanished); and (2) **no scanned source file is absent from the reports** — a file
+  Sonar scans but that no report mentions is zero-coverage'd to 0% (this is how the
+  `apps/api/app/models/**` files, omitted from coverage.py but not from
+  `sonar.coverage.exclusions`, tanked new-code coverage). `sonar.coverage.exclusions`
+  must stay in sync with coverage.py's `omit` and jest's `collectCoverageFrom`
+  negations; this check enforces that. `--no-tests` validates existing reports only.
+  **It does NOT evaluate the Security/Reliability/Maintainability ratings** — those
+  are computed by Sonar's rule engine, not from the coverage reports.
 - **`pnpm sonar:verify --scan`** (needs `SONAR_TOKEN`) — runs the **real scanner**
   with `sonar.qualitygate.wait=true`, which uploads the analysis and blocks until
   SonarCloud returns the gate verdict, failing on **any** condition (security

--- a/scripts/sonar-coverage-check.mjs
+++ b/scripts/sonar-coverage-check.mjs
@@ -25,9 +25,9 @@
 // To reproduce the FULL gate locally, run `scripts/sonar-local.sh --scan` with a
 // SONAR_TOKEN — that uploads the real analysis and waits on the gate verdict.
 
-import { readFileSync, existsSync } from "node:fs";
+import { readFileSync, existsSync, readdirSync, statSync } from "node:fs";
 import { fileURLToPath } from "node:url";
-import { dirname, join, resolve } from "node:path";
+import { dirname, join, resolve, relative } from "node:path";
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const propsPath = join(ROOT, "sonar-project.properties");
@@ -125,6 +125,109 @@ function pct(covered, total) {
   return `${((covered / total) * 100).toFixed(1)}%`;
 }
 
+/** Convert a Sonar/ant glob (with `**` and `*`) to an anchored RegExp. */
+function globToRegex(glob) {
+  let re = "";
+  for (let i = 0; i < glob.length; i++) {
+    const c = glob[i];
+    if (c === "*") {
+      if (glob[i + 1] === "*") {
+        i++;
+        if (glob[i + 1] === "/") {
+          i++;
+          re += "(?:.*/)?"; // `**/` — any leading directories, or none
+        } else {
+          re += ".*"; // trailing `**` — anything under here
+        }
+      } else {
+        re += "[^/]*"; // single `*` — within one path segment
+      }
+    } else if ("\\^$+?.()|[]{}".includes(c)) {
+      re += `\\${c}`;
+    } else {
+      re += c;
+    }
+  }
+  return new RegExp(`^${re}$`);
+}
+
+/** Recursively list files under `dir` (repo-root-relative, forward slashes). */
+function walkFiles(dir) {
+  const out = [];
+  let entries;
+  try {
+    entries = readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return out;
+  }
+  for (const e of entries) {
+    const abs = join(dir, e.name);
+    if (e.isDirectory()) out.push(...walkFiles(abs));
+    else if (e.isFile()) out.push(relative(ROOT, abs).split("\\").join("/"));
+  }
+  return out;
+}
+
+// Source extensions Sonar measures coverage for. `.d.ts` carries no coverage.
+const COVERAGE_EXTS = [".py", ".ts", ".tsx"];
+const isCoverable = (f) => COVERAGE_EXTS.some((x) => f.endsWith(x)) && !f.endsWith(".d.ts");
+
+/**
+ * Does this file produce executable lines Sonar would count? Python modules
+ * always do. A TypeScript file that is pure type declarations (interfaces/types,
+ * no runtime exports or re-exports) compiles to nothing, so it has no lines to
+ * cover and never affects the coverage %. Skipping those avoids false positives
+ * (e.g. the generated `lib/api/types.ts`).
+ */
+function producesCoverage(file) {
+  if (file.endsWith(".py")) return true;
+  let code;
+  try {
+    code = readFileSync(join(ROOT, file), "utf8")
+      .replace(/\/\*[\s\S]*?\*\//g, "")
+      .replace(/^\s*\/\/.*$/gm, "");
+  } catch {
+    return true;
+  }
+  return (
+    /\bexport\s+(default|const|let|var|function|async|class|enum|namespace)\b/.test(code) ||
+    /^\s*(const|let|var|function|class|enum)\s/m.test(code) ||
+    /\bexport\s*\{[^}]*\}\s*from\b/.test(code) // re-export barrel — runtime
+  );
+}
+
+/**
+ * Find source files Sonar will scan (under sonar.sources) that are NOT in any
+ * coverage report and NOT excluded — Sonar's "Zero Coverage Sensor" marks these
+ * 0%, silently dragging down Coverage on New Code. This is the trap where a file
+ * omitted from coverage.py (e.g. apps/api/app/models/*) isn't also listed in
+ * sonar.coverage.exclusions.
+ */
+function findZeroCoverageSources(props, coveredFiles) {
+  const sources = (props["sonar.sources"]?.split(",") ?? []).map((s) => s.trim()).filter(Boolean);
+  const testRes = (props["sonar.test.inclusions"]?.split(",") ?? [])
+    .map((s) => s.trim())
+    .filter(Boolean)
+    .map(globToRegex);
+  const exclRes = (props["sonar.coverage.exclusions"]?.split(",") ?? [])
+    .map((s) => s.trim())
+    .filter(Boolean)
+    .map(globToRegex);
+
+  const flagged = [];
+  for (const src of sources) {
+    for (const file of walkFiles(join(ROOT, src))) {
+      if (!isCoverable(file)) continue;
+      if (testRes.some((r) => r.test(file))) continue; // test file, not production code
+      if (exclRes.some((r) => r.test(file))) continue; // intentionally excluded
+      if (coveredFiles.has(file)) continue; // present in a coverage report
+      if (!producesCoverage(file)) continue; // type-only module — no lines to cover
+      flagged.push(file);
+    }
+  }
+  return flagged.sort();
+}
+
 const props = parseProps(readFileSync(propsPath, "utf8"));
 const reports = [
   ...(props["sonar.javascript.lcov.reportPaths"]?.split(",") ?? []).map((p) => ({
@@ -139,6 +242,7 @@ const reports = [
 
 let problems = 0;
 let missingReports = 0;
+const coveredFiles = new Set();
 
 console.log(`${BOLD}SonarCloud coverage path check${NC} ${DIM}(repo root: ${ROOT})${NC}\n`);
 
@@ -160,6 +264,10 @@ for (const { path, kind } of reports) {
   const resolvesOnDisk = (file) =>
     existsSync(resolve(ROOT, file)) || sources.some((s) => existsSync(resolve(ROOT, s, file)));
   const unresolved = records.filter((r) => !resolvesOnDisk(r.file));
+
+  // Record every file present in a report (repo-root-relative) so we can later
+  // find source files that are ABSENT from all reports.
+  for (const r of records) coveredFiles.add(r.file.split("\\").join("/"));
 
   const totalLines = records.reduce((a, r) => a + r.total, 0);
   const coveredLines = records.reduce((a, r) => a + r.covered, 0);
@@ -185,22 +293,46 @@ for (const { path, kind } of reports) {
   }
 }
 
+// Only hunt for zero-coverage'd sources when the reports are actually present;
+// otherwise every file looks "absent" and the signal is noise.
+let zeroCov = [];
+if (missingReports === 0) {
+  zeroCov = findZeroCoverageSources(props, coveredFiles);
+  if (zeroCov.length > 0) {
+    console.log("");
+    console.log(
+      `${RED}✗${NC} ${BOLD}${zeroCov.length} source file(s)${NC} are scanned by Sonar but absent from every` +
+        ` coverage report ${DIM}(not in sonar.coverage.exclusions)${NC}:`
+    );
+    for (const f of zeroCov.slice(0, 20)) console.log(`    ${RED}zero-coverage${NC} ${f}`);
+    if (zeroCov.length > 20) console.log(`    ${DIM}…and ${zeroCov.length - 20} more${NC}`);
+    console.log(
+      `    ${YELLOW}Sonar's Zero Coverage Sensor marks these 0% on new code. Either add tests,` +
+        ` or — if intentionally not measured (e.g. coverage.py \`omit\`) — add them to` +
+        ` sonar.coverage.exclusions.${NC}`
+    );
+  }
+}
+
 console.log("");
 if (missingReports > 0) {
   console.log(
     `${YELLOW}${missingReports} report(s) missing — generate them with ${BOLD}pnpm test:coverage${NC}${YELLOW} and re-run.${NC}`
   );
 }
-if (problems > 0) {
-  console.log(
-    `${RED}${BOLD}FAIL${NC} ${problems} coverage path(s) won't resolve in SonarCloud (they'd show as 0%).`
-  );
+if (problems > 0 || zeroCov.length > 0) {
+  const bits = [];
+  if (problems > 0) bits.push(`${problems} unresolvable coverage path(s)`);
+  if (zeroCov.length > 0) bits.push(`${zeroCov.length} zero-coverage'd source file(s)`);
+  console.log(`${RED}${BOLD}FAIL${NC} ${bits.join(" + ")} — Sonar would report these as 0% on new code.`);
   process.exit(1);
 }
 if (missingReports > 0) {
   process.exit(1);
 }
-console.log(`${GREEN}${BOLD}OK${NC} every coverage path resolves to a real file — SonarCloud will map it.`);
+console.log(
+  `${GREEN}${BOLD}OK${NC} every coverage path resolves and every scanned source file is in a report.`
+);
 console.log(
   `${DIM}Note: this checks the Coverage dimension only. Security / Reliability /` +
     ` Maintainability ratings are evaluated by the real scan (sonar-local.sh --scan).${NC}`

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -14,17 +14,26 @@ sonar.cpd.exclusions=\
   apps/web/src/lib/api/types.ts,\
   apps/web/src/lib/api/openapi.json
 
-# Exclude from coverage analysis
+# Exclude from coverage analysis. These MUST stay in sync with what the coverage
+# *tools* measure — coverage.py's `omit` (pyproject.toml) for Python and jest's
+# `collectCoverageFrom` negations (apps/web/jest.config.ts) for web. Any source
+# file Sonar scans that is absent from the coverage report gets zero-coverage'd
+# to 0%, silently dragging down "Coverage on New Code". `scripts/sonar-coverage-
+# check.mjs` enforces this alignment locally.
 sonar.coverage.exclusions=\
   **/__init__.py,\
   **/worker/__main__.py,\
+  apps/api/app/models/**,\
   apps/web/src/components/ui/**,\
-  apps/web/src/data/airports.ts,\
-  apps/web/src/app/layout.tsx,\
-  apps/web/src/app/trips/layout.tsx,\
+  apps/web/src/data/**,\
+  apps/web/src/app/**/layout.tsx,\
   apps/web/src/lib/navigation.ts,\
+  apps/web/src/lib/mock-data.ts,\
   apps/web/src/lib/fixtures/**,\
-  apps/web/src/context/ThemeContext.tsx
+  apps/web/src/context/ThemeContext.tsx,\
+  **/index.ts,\
+  **/index.tsx,\
+  **/*.d.ts
 
 # Coverage reports
 sonar.javascript.lcov.reportPaths=apps/web/coverage/lcov.info


### PR DESCRIPTION
## Summary

The gate failed on **Coverage on New Code = 16.9%** after #15 merged. This is **not** untested code — it's the same *class* of bug as the original web-lcov issue, one layer deeper.

**Root cause:** Sonar's "Zero Coverage Sensor" (visible in the scan log) marks any file under `sonar.sources` that's **absent from the coverage report** as 0%. `apps/api/app/models/**` are deliberately omitted from coverage.py (`[tool.coverage.run] omit` — "tested via integration tests") but were **not** listed in `sonar.coverage.exclusions`. So every model file read as 0%, and #15 added a lot of new model code (`notification_outbox.py`, `feature_flag.py`, `user.py`, …), flooding the 30-day new-code window with "uncovered" lines. The same drift existed for web barrels/mock-data that jest's `collectCoverageFrom` excludes but Sonar didn't.

The existing config already mirrors coverage.py's omit for `__init__.py`/`worker/__main__.py` — models (and the web negations) were just never kept in sync.

## Changes

- **`sonar-project.properties`** — align `sonar.coverage.exclusions` with what the coverage *tools* measure: coverage.py's `omit` (`apps/api/app/models/**`) and jest's `collectCoverageFrom` negations (`**/index.ts`, `**/index.tsx`, `mock-data.ts`, `data/**`, `**/*.d.ts`, `app/**/layout.tsx`).
- **`scripts/sonar-coverage-check.mjs`** — teach the local checker to catch this class: flag any source file Sonar scans that no coverage report mentions and that isn't excluded (skipping type-only TS modules that compile to zero runtime, e.g. the generated `lib/api/types.ts`). This is the peer-review gap I never closed in #22 ("validates only paths present, not files the report omits").
- **`nextjs.yml` / `python.yml`** — also trigger on `sonar-project.properties`, so a Sonar-config-only commit still produces coverage artifacts and the gate re-scans (otherwise it's path-filtered out and never re-evaluated — which is also why this PR can verify itself).

## Test plan

- [x] Local checker run: **clean** with the fix (all paths resolve + every scanned runtime source is in a report).
- [x] Proved the detection catches the bug: removing the `models/**` exclusion makes it flag **exactly the 9 model files** from the failing report (`conversation`, `feature_flag`, `message`, `notification_outbox`, `notification_rule`, `price_snapshot`, `trip`, `trip_prefs`, `user`), exit 1.
- [x] Confirmed the 3 `types.ts` files it previously over-flagged have **0 runtime declarations** (pure types → no coverage impact) and are now correctly skipped.
- [x] api/worker/web coverage regenerated; YAML validated.
- [x] Because this PR touches `sonar-project.properties`, the coverage workflows now run on it → **the SonarCloud gate re-evaluates on this PR**, so we'll see Coverage on New Code recover before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VoGSRWAmfDUbq1gkWSDFPX

---
_Generated by [Claude Code](https://claude.ai/code/session_01VoGSRWAmfDUbq1gkWSDFPX)_