### PR TITLE
feat(worker): daily system-health digest email

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -84,6 +84,10 @@ OPTIMIZER_RATE_LIMIT_PER_HOUR=2000
 TEMPORAL_ADDRESS=temporal:7233
 TEMPORAL_NAMESPACE=default
 TEMPORAL_TASK_QUEUE=vacation-tracker-tasks
+# Daily cron schedules (UTC). Refresh fans out price checks + chains the user
+# digest; the health check emails a system summary to ADMIN_EMAILS.
+DAILY_REFRESH_CRON=0 6 * * *
+DAILY_HEALTH_CRON=0 7 * * *
 
 # =============================================================================
 # NOTIFICATIONS
@@ -99,6 +103,10 @@ RESEND_API_KEY=
 EMAIL_FROM=notifications@yourdomain.com
 # CAN-SPAM footer: the sender's physical mailing address, shown in the digest footer.
 EMAIL_PHYSICAL_ADDRESS=
+# --- HEALTH DIGEST (operator alerts) ---
+# Comma-separated recipients for the daily system-health digest (DAILY_HEALTH_CRON).
+# Blank → the health check still runs and logs, but emails nobody.
+ADMIN_EMAILS=
 
 # --- EMAIL (legacy SMTP2GO, unused) ---
 SMTP_HOST=smtp.smtp2go.com
@@ -181,3 +189,8 @@ LANGFUSE_ENVIRONMENT=
 # column schema stays bounded — see docs/specs/operations/axiom-map-fields.md.
 AXIOM_TOKEN=
 AXIOM_DATASET=
+# Read access for the health digest's error-volume check (the ingest token above
+# can't query). Use a Personal Access Token with Query capability + the org slug.
+# Blank → the error-volume check reports `unknown` (skipped).
+AXIOM_QUERY_TOKEN=
+AXIOM_ORG_ID=

--- a/.env.prod.example
+++ b/.env.prod.example
@@ -66,10 +66,19 @@ EMAIL_FROM=Vacation Price Tracker <notifications@your-domain.com>
 # virtual mailbox, NOT your home address.
 EMAIL_PHYSICAL_ADDRESS=
 
+# --- HEALTH DIGEST (operator alerts) ---
+# Comma-separated recipients for the daily system-health digest (DAILY_HEALTH_CRON).
+# Blank → the health check runs and logs, but emails nobody.
+ADMIN_EMAILS=
+
 # --- TEMPORAL ---
 TEMPORAL_ADDRESS=temporal:7233
 TEMPORAL_NAMESPACE=default
 TEMPORAL_TASK_QUEUE=vacation-price-tracker-tasks
+# Daily cron schedules (UTC): price refresh + chained user digest, then the
+# system-health digest one hour later.
+DAILY_REFRESH_CRON=0 6 * * *
+DAILY_HEALTH_CRON=0 7 * * *
 
 # --- REDIS ---
 REDIS_URL=redis://redis:6379/0
@@ -88,3 +97,8 @@ LANGFUSE_ENVIRONMENT=production
 # (docs/specs/operations/axiom-map-fields.md) or the bounded schema silently fails.
 AXIOM_TOKEN=
 AXIOM_DATASET=vacation-price-tracker-prod
+# Read access for the health digest's error-volume check (the ingest token can't
+# query). Personal Access Token with Query capability + org slug. Blank → that
+# check reports `unknown`.
+AXIOM_QUERY_TOKEN=
+AXIOM_ORG_ID=

--- a/README.md
+++ b/README.md
@@ -57,6 +57,17 @@ vacation-price-tracker/
 └── .env.example          # Configuration template
 ```
 
+## Scheduled jobs (cron)
+
+The worker bootstraps two daily Temporal schedules on startup (UTC):
+
+| Cron (env) | Default | Job |
+|:-----------|:--------|:----|
+| `DAILY_REFRESH_CRON` | `0 6 * * *` | Refresh all active trips, then send per-user price-drop digests. |
+| `DAILY_HEALTH_CRON` | `0 7 * * *` | Run system health checks and email an ops summary to `ADMIN_EMAILS`. |
+
+See [`apps/worker/CLAUDE.md`](apps/worker/CLAUDE.md) for details.
+
 ## Setup
 
 ### Prerequisites

--- a/apps/api/app/clients/axiom_query.py
+++ b/apps/api/app/clients/axiom_query.py
@@ -1,0 +1,62 @@
+"""Read-only Axiom query client (for the health digest's error-volume check).
+
+The app's ingest token (`AXIOM_TOKEN`) cannot query; reading needs a Personal
+Access Token with Query capability (`AXIOM_QUERY_TOKEN`) plus the org slug
+(`AXIOM_ORG_ID`). Best-effort: every failure (unconfigured, network, unexpected
+shape) returns ``None`` so the caller degrades to an `unknown` check rather than
+failing the digest.
+"""
+
+import logging
+
+import httpx
+
+from app.core.config import settings
+
+logger = logging.getLogger(__name__)
+
+AXIOM_APL_URL = "https://api.axiom.co/v1/datasets/_apl?format=tabular"
+DEFAULT_TIMEOUT_SECONDS = 15.0
+
+
+async def query_count(apl: str) -> int | None:
+    """Run an APL query that returns a single count; return it, or None on any error.
+
+    Expects an APL ending in ``| count`` (Axiom returns a single row/column).
+    """
+    if not settings.axiom_query_enabled:
+        return None
+    try:
+        async with httpx.AsyncClient(timeout=httpx.Timeout(DEFAULT_TIMEOUT_SECONDS)) as client:
+            response = await client.post(
+                AXIOM_APL_URL,
+                json={"apl": apl},
+                headers={
+                    "Authorization": f"Bearer {settings.axiom_query_token}",
+                    "X-AXIOM-ORG-ID": settings.axiom_org_id,
+                    "Content-Type": "application/json",
+                },
+            )
+            response.raise_for_status()
+            return _extract_count(response.json())
+    except Exception as exc:  # pragma: no cover - network/parse error path
+        logger.warning(
+            "Axiom query failed",
+            exc_info=exc,
+            extra={"event": "axiom.query.failed"},
+        )
+        return None
+
+
+def _extract_count(payload: dict) -> int | None:
+    """Pull the scalar count out of Axiom's tabular response shape."""
+    tables = payload.get("tables") or []
+    for table in tables:
+        columns = table.get("columns") or []
+        # tabular `| count` → a single column with a single row holding the total.
+        if columns and columns[0]:
+            try:
+                return int(columns[0][0])
+            except (TypeError, ValueError, IndexError):
+                return None
+    return None

--- a/apps/api/app/clients/email.py
+++ b/apps/api/app/clients/email.py
@@ -66,7 +66,7 @@ class ResendClient:
     async def send(
         self,
         *,
-        to: str,
+        to: str | list[str],
         subject: str,
         html: str,
         headers: dict[str, str] | None = None,
@@ -74,6 +74,7 @@ class ResendClient:
     ) -> dict:
         """Send a single HTML email.
 
+        ``to`` may be a single address or a list (Resend accepts a ``to`` array).
         Returns the parsed Resend response (``{"id": ...}``) on success, or a
         ``{"dry_run": True}`` marker when no API key is configured.
         """

--- a/apps/api/app/core/config.py
+++ b/apps/api/app/core/config.py
@@ -50,6 +50,7 @@ class Settings(BaseSettings):
     temporal_namespace: str = "default"
     temporal_task_queue: str = "vacation-price-tracker-tasks"
     daily_refresh_cron: str = "0 6 * * *"  # 06:00 UTC daily
+    daily_health_cron: str = "0 7 * * *"  # 07:00 UTC daily — system health digest
 
     # Email Notifications
     smtp_host: str = "smtp.smtp2go.com"
@@ -63,6 +64,10 @@ class Settings(BaseSettings):
     # unsubscribe links reuse frontend_url (app) and backend_url (API).
     resend_api_key: str = ""
     email_physical_address: str = ""  # CAN-SPAM footer; required for real sends
+
+    # Daily system-health digest recipients (comma-separated). Blank → the health
+    # check still runs and logs, but emails nobody.
+    admin_emails: str = ""
 
     # SMS Notifications
     notification_api_key: str = ""
@@ -115,11 +120,26 @@ class Settings(BaseSettings):
     # the `service` field. The `fields` map field bounds the column schema.
     axiom_token: str = ""  # ingest-only API token
     axiom_dataset: str = ""  # e.g. vacation-price-tracker-prod
+    # Read access (the ingest token can't query). A Personal Access Token with
+    # Query capability + the org slug, used by the health digest's error-volume
+    # check. Blank → that check reports `unknown` (skipped).
+    axiom_query_token: str = ""
+    axiom_org_id: str = ""
 
     @property
     def axiom_enabled(self) -> bool:
         """Whether Axiom log shipping is configured."""
         return bool(self.axiom_token and self.axiom_dataset)
+
+    @property
+    def axiom_query_enabled(self) -> bool:
+        """Whether Axiom read/query access is configured (health digest)."""
+        return bool(self.axiom_query_token and self.axiom_org_id and self.axiom_dataset)
+
+    @property
+    def admin_emails_list(self) -> list[str]:
+        """Comma-separated ADMIN_EMAILS recipients for the health digest."""
+        return [e.strip() for e in self.admin_emails.split(",") if e.strip()]
 
     # JWT
     jwt_algorithm: str = "HS256"

--- a/apps/api/app/services/email_render.py
+++ b/apps/api/app/services/email_render.py
@@ -59,3 +59,52 @@ def render_daily_digest(
         format_price=_format_price,
     )
     return subject, html
+
+
+class CheckResult(TypedDict):
+    """One health check's outcome (mirrors showbook's CheckResult)."""
+
+    name: str
+    status: str  # "ok" | "warn" | "fail" | "unknown"
+    summary: str
+    detail: dict | None
+
+
+class FlagState(TypedDict):
+    name: str
+    description: str
+    enabled: bool
+
+
+def render_health_digest(
+    *,
+    status: str,
+    checks: list[CheckResult],
+    flags: list[FlagState],
+    run_at: str,
+    app_url: str,
+) -> tuple[str, str]:
+    """Render the system-health digest. Returns ``(subject, html)``.
+
+    Subject mirrors showbook's ``formatSubject``.
+    """
+    fail = sum(1 for c in checks if c["status"] == "fail")
+    warn = sum(1 for c in checks if c["status"] == "warn")
+    if status == "fail":
+        subject = f"[VPT health] FAIL — {fail} failing check{'' if fail == 1 else 's'}"
+    elif status == "warn":
+        subject = f"[VPT health] WARN — {warn} warning{'' if warn == 1 else 's'}"
+    elif status == "unknown":
+        subject = "[VPT health] UNKNOWN — checks unavailable"
+    else:
+        subject = "[VPT health] OK"
+
+    template = _env.get_template("health_digest.html.j2")
+    html = template.render(
+        status=status,
+        checks=checks,
+        flags=flags,
+        run_at=run_at,
+        app_url=app_url,
+    )
+    return subject, html

--- a/apps/api/app/templates/email/health_digest.html.j2
+++ b/apps/api/app/templates/email/health_digest.html.j2
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>VPT system health</title>
+  </head>
+  {% set banner = {'ok': '#1db954', 'warn': '#f59e0b', 'fail': '#e5484d', 'unknown': '#6b7280'} %}
+  {% set label = {'ok': 'OK', 'warn': 'WARN', 'fail': 'FAIL', 'unknown': 'UNKNOWN'} %}
+  <body style="margin:0; padding:0; background-color:#f4f4f7; font-family:Helvetica,Arial,sans-serif; color:#1a1a2e;">
+    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background-color:#f4f4f7; padding:24px 0;">
+      <tr>
+        <td align="center">
+          <table role="presentation" width="640" cellpadding="0" cellspacing="0" style="max-width:640px; width:100%; background-color:#ffffff; border-radius:8px; overflow:hidden;">
+            <tr>
+              <td style="background-color:{{ banner.get(status, '#6b7280') }}; padding:20px 32px;">
+                <h1 style="margin:0; color:#ffffff; font-size:20px;">
+                  Vacation Price Tracker — {{ label.get(status, 'UNKNOWN') }}
+                </h1>
+                <p style="margin:4px 0 0; color:#ffffff; font-size:13px; opacity:0.9;">{{ run_at }}</p>
+              </td>
+            </tr>
+            <tr>
+              <td style="padding:16px 32px;">
+                <table role="presentation" width="100%" cellpadding="0" cellspacing="0">
+                  {% for c in checks %}
+                  <tr>
+                    <td style="padding:10px 0; border-bottom:1px solid #eee; vertical-align:top; width:84px;">
+                      <span style="display:inline-block; padding:3px 8px; border-radius:4px; font-size:11px; font-weight:bold; color:#ffffff; background-color:{{ banner.get(c.status, '#6b7280') }};">{{ label.get(c.status, 'UNKNOWN') }}</span>
+                    </td>
+                    <td style="padding:10px 0; border-bottom:1px solid #eee;">
+                      <p style="margin:0; font-size:14px; font-weight:bold;">{{ c.name }}</p>
+                      <p style="margin:2px 0 0; font-size:13px; color:#4b5563;">{{ c.summary }}</p>
+                    </td>
+                  </tr>
+                  {% endfor %}
+                </table>
+              </td>
+            </tr>
+            {% if flags %}
+            <tr>
+              <td style="padding:8px 32px 16px;">
+                <p style="margin:0 0 6px; font-size:13px; font-weight:bold; color:#6b7280;">Feature flags</p>
+                {% for f in flags %}
+                <p style="margin:0; font-size:13px; color:#4b5563;">
+                  {{ f.name }}: <strong>{{ 'on' if f.enabled else 'off' }}</strong>
+                </p>
+                {% endfor %}
+              </td>
+            </tr>
+            {% endif %}
+            <tr>
+              <td style="padding:16px 32px; border-top:1px solid #e5e5ef; font-size:12px; color:#9aa0b4;">
+                {% if app_url %}<a href="{{ app_url }}" style="color:#6b7280;">Open dashboard</a> · {% endif %}
+                Automated system-health digest.
+              </td>
+            </tr>
+          </table>
+        </td>
+      </tr>
+    </table>
+  </body>
+</html>

--- a/apps/api/tests/clients/test_axiom_query.py
+++ b/apps/api/tests/clients/test_axiom_query.py
@@ -1,0 +1,66 @@
+"""Tests for the read-only Axiom query client."""
+
+import pytest
+from app.clients import axiom_query as aq
+from app.clients.axiom_query import query_count
+
+
+class _FakeResponse:
+    def __init__(self, payload: dict) -> None:
+        self._payload = payload
+
+    def raise_for_status(self) -> None:
+        return None
+
+    def json(self) -> dict:
+        return self._payload
+
+
+class _FakeAsyncClient:
+    payload: dict = {"tables": [{"columns": [[7]]}]}
+
+    def __init__(self, *_args, **_kwargs) -> None:
+        pass
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_exc):
+        return None
+
+    async def post(self, _url, json, headers):
+        return _FakeResponse(_FakeAsyncClient.payload)
+
+
+@pytest.mark.asyncio
+async def test_query_count_disabled_returns_none(monkeypatch):
+    monkeypatch.setattr(aq.settings, "axiom_query_token", "")
+    assert await query_count("['ds'] | count") is None
+
+
+@pytest.mark.asyncio
+async def test_query_count_parses_tabular(monkeypatch):
+    monkeypatch.setattr(aq.settings, "axiom_query_token", "tok")
+    monkeypatch.setattr(aq.settings, "axiom_org_id", "org")
+    monkeypatch.setattr(aq.settings, "axiom_dataset", "ds")
+    monkeypatch.setattr(aq.httpx, "AsyncClient", _FakeAsyncClient)
+
+    assert await query_count("['ds'] | count") == 7
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"tables": []},  # no tables
+        {"tables": [{"columns": [["not-a-number"]]}]},  # non-numeric cell
+    ],
+)
+async def test_query_count_unexpected_shape_returns_none(monkeypatch, payload):
+    monkeypatch.setattr(aq.settings, "axiom_query_token", "tok")
+    monkeypatch.setattr(aq.settings, "axiom_org_id", "org")
+    monkeypatch.setattr(aq.settings, "axiom_dataset", "ds")
+    monkeypatch.setattr(_FakeAsyncClient, "payload", payload)
+    monkeypatch.setattr(aq.httpx, "AsyncClient", _FakeAsyncClient)
+
+    assert await query_count("['ds'] | count") is None

--- a/apps/api/tests/services/test_email_render.py
+++ b/apps/api/tests/services/test_email_render.py
@@ -2,7 +2,52 @@
 
 from decimal import Decimal
 
-from app.services.email_render import DigestTrip, render_daily_digest
+from app.services.email_render import DigestTrip, render_daily_digest, render_health_digest
+
+
+def _checks(*statuses: str):
+    return [
+        {"name": f"check_{i}", "status": s, "summary": f"summary {i}", "detail": None}
+        for i, s in enumerate(statuses)
+    ]
+
+
+def test_render_health_digest_ok_subject():
+    subject, html = render_health_digest(
+        status="ok",
+        checks=_checks("ok", "ok"),
+        flags=[{"name": "email_notifications", "description": "x", "enabled": True}],
+        run_at="2026-06-24 07:00 UTC",
+        app_url="https://app.test",
+    )
+    assert subject == "[VPT health] OK"
+    assert "check_0" in html
+    assert "email_notifications" in html
+
+
+def test_render_health_digest_fail_subject_counts():
+    subject, _ = render_health_digest(
+        status="fail",
+        checks=_checks("ok", "fail", "fail"),
+        flags=[],
+        run_at="now",
+        app_url="",
+    )
+    assert subject == "[VPT health] FAIL — 2 failing checks"
+
+
+def test_render_health_digest_warn_singular():
+    subject, _ = render_health_digest(
+        status="warn", checks=_checks("ok", "warn"), flags=[], run_at="now", app_url=""
+    )
+    assert subject == "[VPT health] WARN — 1 warning"
+
+
+def test_render_health_digest_unknown():
+    subject, _ = render_health_digest(
+        status="unknown", checks=_checks("unknown"), flags=[], run_at="now", app_url=""
+    )
+    assert subject == "[VPT health] UNKNOWN — checks unavailable"
 
 
 def _trip(name: str = "Maui Getaway") -> DigestTrip:

--- a/apps/worker/CLAUDE.md
+++ b/apps/worker/CLAUDE.md
@@ -30,12 +30,36 @@ apps/worker/tests/       # pytest; integration tests marked `-m integration`
 
 95% coverage gate, same as the API.
 
+## Scheduled jobs (cron)
+
+Temporal schedules are created/updated idempotently on worker startup by
+`schedule_bootstrap.py` (`ensure_daily_refresh_schedule` + `ensure_daily_health_schedule`),
+all with `ScheduleOverlapPolicy.SKIP`. Times are UTC.
+
+| Schedule id | Cron (env) | Default | Workflow | What it does |
+|:------------|:-----------|:--------|:---------|:-------------|
+| `daily-price-refresh` | `DAILY_REFRESH_CRON` | `0 6 * * *` | `ScheduledRefreshAllUsersWorkflow` | Refresh every active trip, then chain the user price-drop digest. |
+| `daily-health-check` | `DAILY_HEALTH_CRON` | `0 7 * * *` | `RunHealthCheckWorkflow` | Run system health checks and email an ops summary to `ADMIN_EMAILS`. |
+
+The health check runs an hour after the refresh so it reports on the overnight run.
+
 ## Workflows
 
 ### RefreshAllTripsWorkflow
 Orchestrates updating all active trips for a user. Triggered by the manual refresh
 button (`POST /v1/trips/refresh-all`) and the daily cron (`daily_refresh_cron`,
 default `0 6 * * *`).
+
+### RunHealthCheckWorkflow
+Daily system-health digest (showbook's `runHealthCheck` analog). One activity
+(`run_health_check_activity`) runs independent checks in parallel — each catching
+its own errors → a `CheckResult{name, status: ok|warn|fail|unknown, summary}` —
+rolls them up, and emails a color-coded summary to `ADMIN_EMAILS` via `ResendClient`
+(idempotency key `health-summary-{date}`; skips when `ADMIN_EMAILS`/`RESEND_API_KEY`
+unset; **never throws**). Checks: DB/Redis/Temporal connectivity, snapshot
+freshness, errored trips, notification-outbox failures, Groq/Skiplagged daily-budget
+usage, last refresh-run outcome (Temporal history), and Axiom error volume
+(`unknown` when `AXIOM_QUERY_TOKEN` unset). Subject: `[VPT health] OK|FAIL|WARN|UNKNOWN`.
 
 ### PriceCheckWorkflow
 Single trip, saga-style (Temporal handles retries/compensation):

--- a/apps/worker/tests/integration/test_schedule_integration.py
+++ b/apps/worker/tests/integration/test_schedule_integration.py
@@ -28,6 +28,7 @@ from worker.schedule_bootstrap import (
     WORKFLOW_NAME,
     ensure_daily_refresh_schedule,
 )
+from worker.workflows.health_check import RunHealthCheckWorkflow
 from worker.workflows.scheduled_refresh import ScheduledRefreshAllUsersWorkflow
 from worker.workflows.send_daily_digests import SendDailyDigestsWorkflow
 
@@ -60,6 +61,12 @@ async def _fake_get_pending_digest_user_ids() -> list[str]:
 async def _fake_send_user_digest(_user_id: str) -> dict:
     """Stub activity — not reached when there are no pending digests."""
     return {"sent": False, "count": 0}
+
+
+@activity.defn(name="run_health_check_activity")
+async def _fake_run_health_check() -> dict:
+    """Stub activity — registered so RunHealthCheckWorkflow stays sandbox-valid."""
+    return {"status": "ok", "sent": 0, "skipped": True, "ok": 0, "warn": 0, "fail": 0, "unknown": 0}
 
 
 async def _wait_for_recent_actions(handle, timeout_seconds: float = 20.0):
@@ -116,12 +123,17 @@ async def test_schedule_trigger_runs_configured_workflow(monkeypatch):
         async with Worker(
             env.client,
             task_queue=_TEST_TASK_QUEUE,
-            workflows=[ScheduledRefreshAllUsersWorkflow, SendDailyDigestsWorkflow],
+            workflows=[
+                ScheduledRefreshAllUsersWorkflow,
+                SendDailyDigestsWorkflow,
+                RunHealthCheckWorkflow,
+            ],
             activities=[
                 _fake_get_all_user_ids,
                 _fake_expire_past_trips,
                 _fake_get_pending_digest_user_ids,
                 _fake_send_user_digest,
+                _fake_run_health_check,
             ],
         ):
             await ensure_daily_refresh_schedule(env.client)

--- a/apps/worker/tests/test_health_check_activity.py
+++ b/apps/worker/tests/test_health_check_activity.py
@@ -1,0 +1,415 @@
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+import pytest_asyncio
+from app.core.constants import NotificationStatus, TripStatus
+from app.models.notification_outbox import NotificationOutbox
+from app.models.price_snapshot import PriceSnapshot
+from app.models.trip import Trip
+from app.models.user import User
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+from sqlmodel import SQLModel
+from worker.activities import health_check as hc
+
+NOW = datetime.now(UTC)
+
+
+class _FakeRedis:
+    def __init__(self, *, ping_ok: bool = True, get_value: str | None = None) -> None:
+        self._ping_ok = ping_ok
+        self._get_value = get_value
+
+    async def ping(self):
+        if not self._ping_ok:
+            raise RuntimeError("redis down")
+        return True
+
+    async def get(self, _key):
+        return self._get_value
+
+
+class _FakeResend:
+    def __init__(self) -> None:
+        self.calls: list[dict] = []
+
+    async def send(self, **kwargs):
+        self.calls.append(kwargs)
+        return {"id": "h1"}
+
+
+class _BoomResend:
+    async def send(self, **_kwargs):
+        from app.clients.email import EmailSendError
+
+        raise EmailSendError("resend down")
+
+
+class _BoomSession:
+    async def __aenter__(self):
+        raise RuntimeError("db down")
+
+    async def __aexit__(self, *_exc):
+        return None
+
+
+class _RaisingGetRedis:
+    async def ping(self):
+        return True
+
+    async def get(self, _key):
+        raise RuntimeError("redis get boom")
+
+
+@pytest_asyncio.fixture
+async def configured(monkeypatch):
+    import app.models  # noqa: F401 - register tables
+
+    engine = create_async_engine(
+        "sqlite+aiosqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    async with engine.begin() as conn:
+        await conn.run_sync(SQLModel.metadata.create_all)
+    factory = async_sessionmaker(bind=engine, class_=AsyncSession, expire_on_commit=False)
+
+    monkeypatch.setattr(hc, "AsyncSessionLocal", factory)
+    monkeypatch.setattr(hc, "redis_client", _FakeRedis())
+    # Baseline: Temporal up with a clean last refresh, so individual tests isolate
+    # whatever they break. Override _connect_temporal to test the down path.
+    monkeypatch.setattr(
+        hc,
+        "_connect_temporal",
+        AsyncMock(
+            return_value=_temporal_client(
+                recent_actions=[_action()],
+                wf_result={"users_total": 1, "users_successful": 1, "users_failed": 0},
+            )
+        ),
+    )
+    monkeypatch.setattr(hc.settings, "admin_emails", "ops@example.com")
+    monkeypatch.setattr(hc.settings, "axiom_query_token", "")  # error_volume → unknown
+    monkeypatch.setattr(hc.settings, "frontend_url", "https://app.test")
+
+    yield factory
+    await engine.dispose()
+
+
+async def _seed(factory, *, snapshots_24h=1, error_trips=0, failed_outbox=0):
+    async with factory() as session:
+        user = User(email="t@example.com", google_sub=f"s-{uuid.uuid4()}")
+        session.add(user)
+        await session.flush()
+        trip = Trip(
+            user_id=user.id,
+            name="Trip",
+            origin_airport="SFO",
+            destination_code="OGG",
+            depart_date=datetime(2026, 12, 1).date(),
+            status=TripStatus.ACTIVE,
+        )
+        session.add(trip)
+        await session.flush()
+        for _ in range(snapshots_24h):
+            session.add(PriceSnapshot(trip_id=trip.id, total_price=None, created_at=NOW))
+        for _ in range(error_trips):
+            session.add(
+                Trip(
+                    user_id=user.id,
+                    name=f"err-{uuid.uuid4()}",
+                    origin_airport="SFO",
+                    destination_code="OGG",
+                    depart_date=datetime(2026, 12, 1).date(),
+                    status=TripStatus.ERROR,
+                )
+            )
+        for _ in range(failed_outbox):
+            session.add(
+                NotificationOutbox(
+                    user_id=user.id,
+                    trip_id=trip.id,
+                    snapshot_id=uuid.uuid4(),
+                    new_price=1,
+                    status=NotificationStatus.FAILED,
+                )
+            )
+        await session.commit()
+
+
+@pytest.mark.asyncio
+async def test_sends_digest_to_admins(configured, monkeypatch):
+    fake = _FakeResend()
+    monkeypatch.setattr(hc, "ResendClient", lambda: fake)
+    await _seed(configured, snapshots_24h=3)
+
+    result = await hc.run_health_check_activity()
+
+    assert result["sent"] == 1
+    assert result["skipped"] is False
+    assert len(fake.calls) == 1
+    call = fake.calls[0]
+    assert call["to"] == ["ops@example.com"]
+    assert call["subject"].startswith("[VPT health]")
+    assert call["idempotency_key"].startswith("health-summary-")
+
+
+@pytest.mark.asyncio
+async def test_skips_when_no_admins(configured, monkeypatch):
+    fake = _FakeResend()
+    monkeypatch.setattr(hc, "ResendClient", lambda: fake)
+    monkeypatch.setattr(hc.settings, "admin_emails", "")
+    await _seed(configured)
+
+    result = await hc.run_health_check_activity()
+
+    assert result["skipped"] is True
+    assert result["sent"] == 0
+    assert fake.calls == []
+
+
+@pytest.mark.asyncio
+async def test_no_snapshots_is_fail(configured, monkeypatch):
+    fake = _FakeResend()
+    monkeypatch.setattr(hc, "ResendClient", lambda: fake)
+    await _seed(configured, snapshots_24h=0)
+
+    result = await hc.run_health_check_activity()
+
+    assert result["status"] == "fail"
+    assert result["sent"] == 1
+    assert fake.calls[0]["subject"].startswith("[VPT health] FAIL")
+
+
+@pytest.mark.asyncio
+async def test_email_failure_is_swallowed(configured, monkeypatch):
+    monkeypatch.setattr(hc, "ResendClient", lambda: _BoomResend())
+    await _seed(configured)
+
+    result = await hc.run_health_check_activity()
+
+    assert result["sent"] == 0
+    assert result["skipped"] is False  # attempted, but failed gracefully
+
+
+@pytest.mark.asyncio
+async def test_redis_down_marks_fail(configured, monkeypatch):
+    monkeypatch.setattr(hc, "redis_client", _FakeRedis(ping_ok=False))
+    monkeypatch.setattr(hc, "ResendClient", lambda: _FakeResend())
+    await _seed(configured)
+
+    result = await hc.run_health_check_activity()
+    assert result["status"] == "fail"
+
+
+@pytest.mark.asyncio
+async def test_budget_warn_threshold(configured, monkeypatch):
+    # 90% of the Groq ceiling → warn (no fail elsewhere if snapshots present).
+    monkeypatch.setattr(hc.settings, "global_daily_groq_token_budget", 1000)
+    monkeypatch.setattr(hc, "redis_client", _FakeRedis(get_value="900"))
+    monkeypatch.setattr(hc, "ResendClient", lambda: _FakeResend())
+    await _seed(configured, snapshots_24h=2)
+
+    result = await hc.run_health_check_activity()
+    assert result["warn"] >= 1
+
+
+@pytest.mark.asyncio
+async def test_error_volume_check_uses_axiom(configured, monkeypatch):
+    monkeypatch.setattr(hc.settings, "axiom_query_token", "tok")
+    monkeypatch.setattr(hc.settings, "axiom_org_id", "org")
+    monkeypatch.setattr(hc.settings, "axiom_dataset", "ds")
+    monkeypatch.setattr(hc, "query_count", AsyncMock(return_value=150))
+    monkeypatch.setattr(hc, "ResendClient", lambda: _FakeResend())
+    await _seed(configured, snapshots_24h=2)
+
+    result = await hc.run_health_check_activity()
+    assert result["status"] == "fail"  # 150 errors ≥ fail threshold
+
+
+@pytest.mark.asyncio
+async def test_error_trips_and_failed_notifications_warn(configured, monkeypatch):
+    monkeypatch.setattr(hc, "ResendClient", lambda: _FakeResend())
+    await _seed(configured, snapshots_24h=2, error_trips=2, failed_outbox=1)
+
+    result = await hc.run_health_check_activity()
+    assert result["status"] == "warn"
+    assert result["warn"] >= 2  # failed_trips + notifications
+
+
+@pytest.mark.asyncio
+async def test_budget_fail_when_over_ceiling(configured, monkeypatch):
+    monkeypatch.setattr(hc.settings, "global_daily_skiplagged_call_budget", 100)
+    monkeypatch.setattr(hc, "redis_client", _FakeRedis(get_value="100"))
+    monkeypatch.setattr(hc, "ResendClient", lambda: _FakeResend())
+    await _seed(configured, snapshots_24h=2)
+
+    result = await hc.run_health_check_activity()
+    assert result["status"] == "fail"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(("count", "expected"), [(0, "ok"), (5, "warn")])
+async def test_error_volume_levels(configured, monkeypatch, count, expected):
+    monkeypatch.setattr(hc.settings, "axiom_query_token", "tok")
+    monkeypatch.setattr(hc.settings, "axiom_org_id", "org")
+    monkeypatch.setattr(hc.settings, "axiom_dataset", "ds")
+    monkeypatch.setattr(hc, "query_count", AsyncMock(return_value=count))
+    monkeypatch.setattr(hc, "ResendClient", lambda: _FakeResend())
+    await _seed(configured, snapshots_24h=2)
+
+    result = await hc.run_health_check_activity()
+    statuses = {expected}
+    # ok path → overall ok; warn path → overall warn (no other warn/fail expected).
+    assert result["status"] in statuses
+
+
+def _temporal_client(*, recent_actions, wf_status="COMPLETED", wf_result=None):
+    sched = SimpleNamespace(info=SimpleNamespace(recent_actions=recent_actions))
+    wf = SimpleNamespace(
+        describe=AsyncMock(return_value=SimpleNamespace(status=SimpleNamespace(name=wf_status))),
+        result=AsyncMock(return_value=wf_result),
+    )
+    return SimpleNamespace(
+        get_schedule_handle=lambda _id: SimpleNamespace(describe=AsyncMock(return_value=sched)),
+        get_workflow_handle=lambda *_a, **_k: wf,
+    )
+
+
+def _action():
+    return SimpleNamespace(
+        action=SimpleNamespace(workflow_id="scheduled-refresh-all-users", first_execution_run_id="r1")
+    )
+
+
+@pytest.mark.asyncio
+async def test_refresh_run_no_actions_warn(configured, monkeypatch):
+    monkeypatch.setattr(hc, "_connect_temporal", AsyncMock(return_value=_temporal_client(recent_actions=[])))
+    monkeypatch.setattr(hc, "ResendClient", lambda: _FakeResend())
+    await _seed(configured, snapshots_24h=2)
+    result = await hc.run_health_check_activity()
+    assert result["status"] == "warn"
+
+
+@pytest.mark.asyncio
+async def test_refresh_run_completed_with_failures_warn(configured, monkeypatch):
+    client = _temporal_client(
+        recent_actions=[_action()],
+        wf_result={"users_total": 3, "users_successful": 2, "users_failed": 1},
+    )
+    monkeypatch.setattr(hc, "_connect_temporal", AsyncMock(return_value=client))
+    monkeypatch.setattr(hc, "ResendClient", lambda: _FakeResend())
+    await _seed(configured, snapshots_24h=2)
+    result = await hc.run_health_check_activity()
+    assert result["status"] == "warn"
+
+
+@pytest.mark.asyncio
+async def test_refresh_run_failed_status_is_fail(configured, monkeypatch):
+    client = _temporal_client(recent_actions=[_action()], wf_status="FAILED")
+    monkeypatch.setattr(hc, "_connect_temporal", AsyncMock(return_value=client))
+    monkeypatch.setattr(hc, "ResendClient", lambda: _FakeResend())
+    await _seed(configured, snapshots_24h=2)
+    result = await hc.run_health_check_activity()
+    assert result["status"] == "fail"
+
+
+def test_rollup_precedence():
+    mk = lambda s: {"name": "x", "status": s, "summary": "", "detail": None}  # noqa: E731
+    assert hc._rollup([mk("ok"), mk("fail"), mk("warn")]) == "fail"
+    assert hc._rollup([mk("ok"), mk("warn")]) == "warn"
+    assert hc._rollup([mk("unknown"), mk("unknown")]) == "unknown"
+    assert hc._rollup([mk("ok"), mk("unknown")]) == "ok"
+
+
+@pytest.mark.asyncio
+async def test_refresh_run_running_is_ok(configured, monkeypatch):
+    client = _temporal_client(recent_actions=[_action()], wf_status="RUNNING")
+    monkeypatch.setattr(hc, "_connect_temporal", AsyncMock(return_value=client))
+    monkeypatch.setattr(hc, "ResendClient", lambda: _FakeResend())
+    await _seed(configured, snapshots_24h=2)
+    assert (await hc.run_health_check_activity())["status"] == "ok"
+
+
+@pytest.mark.asyncio
+async def test_refresh_run_completed_non_dict_result(configured, monkeypatch):
+    client = _temporal_client(recent_actions=[_action()], wf_status="COMPLETED", wf_result=None)
+    monkeypatch.setattr(hc, "_connect_temporal", AsyncMock(return_value=client))
+    monkeypatch.setattr(hc, "ResendClient", lambda: _FakeResend())
+    await _seed(configured, snapshots_24h=2)
+    assert (await hc.run_health_check_activity())["status"] == "ok"
+
+
+@pytest.mark.asyncio
+async def test_temporal_down_marks_fail_and_refresh_unknown(configured, monkeypatch):
+    monkeypatch.setattr(hc, "_connect_temporal", AsyncMock(return_value=None))
+    monkeypatch.setattr(hc, "ResendClient", lambda: _FakeResend())
+    await _seed(configured, snapshots_24h=2)
+    result = await hc.run_health_check_activity()
+    assert result["status"] == "fail"  # temporal check fails
+    assert result["unknown"] >= 1  # refresh_run + error_volume unknown
+
+
+@pytest.mark.asyncio
+async def test_db_check_errors_handled(configured, monkeypatch):
+    monkeypatch.setattr(hc, "AsyncSessionLocal", lambda: _BoomSession())
+    monkeypatch.setattr(hc, "ResendClient", lambda: _FakeResend())
+    result = await hc.run_health_check_activity()
+    assert result["status"] == "fail"  # database/data_freshness/etc. all fail gracefully
+
+
+@pytest.mark.asyncio
+async def test_budget_read_error_is_unknown(configured, monkeypatch):
+    monkeypatch.setattr(hc, "redis_client", _RaisingGetRedis())
+    monkeypatch.setattr(hc, "ResendClient", lambda: _FakeResend())
+    await _seed(configured, snapshots_24h=2)
+    result = await hc.run_health_check_activity()
+    assert result["unknown"] >= 2  # both budget checks → unknown
+
+
+@pytest.mark.asyncio
+async def test_error_volume_query_failure_is_unknown(configured, monkeypatch):
+    monkeypatch.setattr(hc.settings, "axiom_query_token", "tok")
+    monkeypatch.setattr(hc.settings, "axiom_org_id", "org")
+    monkeypatch.setattr(hc.settings, "axiom_dataset", "ds")
+    monkeypatch.setattr(hc, "query_count", AsyncMock(return_value=None))
+    monkeypatch.setattr(hc, "ResendClient", lambda: _FakeResend())
+    await _seed(configured, snapshots_24h=2)
+    result = await hc.run_health_check_activity()
+    assert result["unknown"] >= 1
+
+
+@pytest.mark.asyncio
+async def test_connect_temporal_returns_none_on_error(monkeypatch):
+    monkeypatch.setattr(hc.Client, "connect", AsyncMock(side_effect=RuntimeError("no temporal")))
+    assert await hc._connect_temporal() is None
+
+
+@pytest.mark.asyncio
+async def test_refresh_run_from_temporal_history(configured, monkeypatch):
+    # Fake a completed scheduled-refresh run with no failures.
+    action = SimpleNamespace(
+        action=SimpleNamespace(workflow_id="scheduled-refresh-all-users", first_execution_run_id="r1")
+    )
+    sched = SimpleNamespace(info=SimpleNamespace(recent_actions=[action]))
+    wf = SimpleNamespace(
+        describe=AsyncMock(return_value=SimpleNamespace(status=SimpleNamespace(name="COMPLETED"))),
+        result=AsyncMock(return_value={"users_total": 3, "users_successful": 3, "users_failed": 0}),
+    )
+    client = SimpleNamespace(
+        get_schedule_handle=lambda _id: SimpleNamespace(describe=AsyncMock(return_value=sched)),
+        get_workflow_handle=lambda *_a, **_k: wf,
+    )
+    monkeypatch.setattr(hc, "_connect_temporal", AsyncMock(return_value=client))
+    monkeypatch.setattr(hc, "ResendClient", lambda: _FakeResend())
+    await _seed(configured, snapshots_24h=2)
+
+    result = await hc.run_health_check_activity()
+    # database/redis/temporal/data_freshness/failed_trips/notifications/budgets/refresh_run ok,
+    # error_volume unknown → rollup ok.
+    assert result["status"] == "ok"

--- a/apps/worker/tests/test_main.py
+++ b/apps/worker/tests/test_main.py
@@ -39,6 +39,7 @@ async def test_main_triggers_shutdown_on_signal(monkeypatch):
     monkeypatch.setattr(worker_main, "Worker", lambda *args, **kwargs: dummy_worker)
     monkeypatch.setattr(worker_main, "Client", SimpleNamespace(connect=DummyClient.connect))
     monkeypatch.setattr(worker_main, "ensure_daily_refresh_schedule", _noop_ensure_schedule)
+    monkeypatch.setattr(worker_main, "ensure_daily_health_schedule", _noop_ensure_schedule)
 
     loop = asyncio.get_running_loop()
 
@@ -59,6 +60,7 @@ async def test_main_exits_when_worker_finishes(monkeypatch):
     monkeypatch.setattr(worker_main, "Worker", lambda *args, **kwargs: dummy_worker)
     monkeypatch.setattr(worker_main, "Client", SimpleNamespace(connect=DummyClient.connect))
     monkeypatch.setattr(worker_main, "ensure_daily_refresh_schedule", _noop_ensure_schedule)
+    monkeypatch.setattr(worker_main, "ensure_daily_health_schedule", _noop_ensure_schedule)
 
     loop = asyncio.get_running_loop()
 
@@ -79,6 +81,7 @@ async def test_main_uses_signal_fallback(monkeypatch):
     monkeypatch.setattr(worker_main, "Worker", lambda *args, **kwargs: dummy_worker)
     monkeypatch.setattr(worker_main, "Client", SimpleNamespace(connect=DummyClient.connect))
     monkeypatch.setattr(worker_main, "ensure_daily_refresh_schedule", _noop_ensure_schedule)
+    monkeypatch.setattr(worker_main, "ensure_daily_health_schedule", _noop_ensure_schedule)
 
     loop = asyncio.get_running_loop()
 

--- a/apps/worker/tests/test_schedule_bootstrap.py
+++ b/apps/worker/tests/test_schedule_bootstrap.py
@@ -114,3 +114,32 @@ async def test_ensure_daily_health_schedule_creates_when_missing(monkeypatch):
     assert schedule.action.workflow == schedule_bootstrap.HEALTH_WORKFLOW_NAME
     assert schedule.spec.cron_expressions
     assert observations[-1]["output"] == {"action": "created"}
+
+
+@pytest.mark.asyncio
+async def test_ensure_daily_health_schedule_updates_when_exists(monkeypatch):
+    observations: list[dict] = []
+    monkeypatch.setattr(
+        schedule_bootstrap.langfuse_context, "update_current_trace", lambda **kwargs: None
+    )
+    monkeypatch.setattr(
+        schedule_bootstrap.langfuse_context,
+        "update_current_observation",
+        lambda **kwargs: observations.append(kwargs),
+    )
+
+    handle = FakeScheduleHandle()
+
+    class HealthClient:
+        def __init__(self) -> None:
+            self.create_schedule = AsyncMock(side_effect=ScheduleAlreadyRunningError())
+
+        def get_schedule_handle(self, schedule_id: str) -> FakeScheduleHandle:
+            assert schedule_id == schedule_bootstrap.HEALTH_SCHEDULE_ID
+            return handle
+
+    await schedule_bootstrap.ensure_daily_health_schedule(HealthClient())
+
+    assert isinstance(handle.update_called_with, ScheduleUpdate)
+    assert handle.update_called_with.schedule.action.workflow == schedule_bootstrap.HEALTH_WORKFLOW_NAME
+    assert observations[-1]["output"] == {"action": "updated"}

--- a/apps/worker/tests/test_schedule_bootstrap.py
+++ b/apps/worker/tests/test_schedule_bootstrap.py
@@ -90,3 +90,27 @@ async def test_ensure_daily_refresh_schedule_updates_when_exists(monkeypatch):
     assert trace_updates[0]["name"] == "schedule_bootstrap"
     assert "schedule_bootstrap" in trace_updates[0]["tags"]
     assert observations[-1]["output"] == {"action": "updated"}
+
+
+@pytest.mark.asyncio
+async def test_ensure_daily_health_schedule_creates_when_missing(monkeypatch):
+    observations: list[dict] = []
+    monkeypatch.setattr(
+        schedule_bootstrap.langfuse_context, "update_current_trace", lambda **kwargs: None
+    )
+    monkeypatch.setattr(
+        schedule_bootstrap.langfuse_context,
+        "update_current_observation",
+        lambda **kwargs: observations.append(kwargs),
+    )
+
+    client = FakeClient(already_exists=False)
+
+    await schedule_bootstrap.ensure_daily_health_schedule(client)
+
+    client.create_schedule.assert_awaited_once()
+    schedule_id, schedule = client.create_schedule.await_args.args
+    assert schedule_id == schedule_bootstrap.HEALTH_SCHEDULE_ID
+    assert schedule.action.workflow == schedule_bootstrap.HEALTH_WORKFLOW_NAME
+    assert schedule.spec.cron_expressions
+    assert observations[-1]["output"] == {"action": "created"}

--- a/apps/worker/tests/test_schedule_cron.py
+++ b/apps/worker/tests/test_schedule_cron.py
@@ -36,8 +36,19 @@ def test_daily_refresh_cron_default_fires_at_0600_utc():
 
 
 def test_schedule_spec_embeds_configured_cron():
-    schedule = _build_schedule()
+    schedule = _build_schedule(
+        "ScheduledRefreshAllUsersWorkflow",
+        "scheduled-refresh-all-users",
+        settings.daily_refresh_cron,
+    )
     assert schedule.spec.cron_expressions == [settings.daily_refresh_cron]
+
+
+def test_daily_health_cron_default_fires_at_0700_utc():
+    assert settings.daily_health_cron == "0 7 * * *"
+    base = datetime(2026, 4, 21, 3, 0, tzinfo=UTC)
+    next_fire = croniter(settings.daily_health_cron, base).get_next(datetime)
+    assert next_fire == datetime(2026, 4, 21, 7, 0, tzinfo=UTC)
 
 
 @pytest.mark.parametrize(

--- a/apps/worker/worker/__main__.py
+++ b/apps/worker/worker/__main__.py
@@ -14,6 +14,7 @@ from temporalio.worker.workflow_sandbox import (
     SandboxRestrictions,
 )
 
+from worker.activities.health_check import run_health_check_activity
 from worker.activities.notifications import (
     evaluate_notifications_activity,
     get_pending_digest_user_ids,
@@ -32,7 +33,11 @@ from worker.activities.trips import (
     get_active_trips,
     get_all_user_ids_with_active_trips,
 )
-from worker.schedule_bootstrap import ensure_daily_refresh_schedule
+from worker.schedule_bootstrap import (
+    ensure_daily_health_schedule,
+    ensure_daily_refresh_schedule,
+)
+from worker.workflows.health_check import RunHealthCheckWorkflow
 from worker.workflows.price_check import PriceCheckWorkflow
 from worker.workflows.refresh_all_trips import RefreshAllTripsWorkflow
 from worker.workflows.scheduled_refresh import ScheduledRefreshAllUsersWorkflow
@@ -44,6 +49,7 @@ async def main() -> None:
     client = await Client.connect(settings.temporal_address, namespace=settings.temporal_namespace)
 
     await ensure_daily_refresh_schedule(client)
+    await ensure_daily_health_schedule(client)
 
     # Configure sandbox to pass through modules that are only used in activities
     sandbox_runner = SandboxedWorkflowRunner(
@@ -62,6 +68,7 @@ async def main() -> None:
             PriceCheckWorkflow,
             ScheduledRefreshAllUsersWorkflow,
             SendDailyDigestsWorkflow,
+            RunHealthCheckWorkflow,
         ],
         activities=[
             get_active_trips,
@@ -76,6 +83,7 @@ async def main() -> None:
             evaluate_notifications_activity,
             get_pending_digest_user_ids,
             send_user_digest_activity,
+            run_health_check_activity,
         ],
         graceful_shutdown_timeout=timedelta(seconds=30),
         workflow_runner=sandbox_runner,

--- a/apps/worker/worker/activities/health_check.py
+++ b/apps/worker/worker/activities/health_check.py
@@ -1,0 +1,327 @@
+"""Daily system-health digest (showbook-style).
+
+Runs independent checks in parallel — each catching its own errors and returning
+a ``CheckResult`` — rolls them up to an overall status, and emails a summary to
+``ADMIN_EMAILS`` via the shared ``ResendClient``. Never throws: a single check or
+the email failing must not fail the workflow.
+
+Axiom-backed checks return ``unknown`` when the query token is unset (mirrors
+showbook's skip semantics); DB/infra checks run without Axiom.
+"""
+
+import asyncio
+import logging
+from datetime import UTC, datetime, timedelta
+
+from app.clients.axiom_query import query_count
+from app.clients.email import EmailError, ResendClient
+from app.core.cache_keys import CacheKeys
+from app.core.config import settings
+from app.core.constants import NotificationStatus, TripStatus
+from app.core.feature_flags import list_feature_flags
+from app.db.redis import redis_client
+from app.db.session import AsyncSessionLocal
+from app.models.notification_outbox import NotificationOutbox
+from app.models.price_snapshot import PriceSnapshot
+from app.models.trip import Trip
+from app.services.email_render import CheckResult, render_health_digest
+from sqlalchemy import func, text
+from sqlmodel import select
+from temporalio import activity
+from temporalio.client import Client
+
+logger = logging.getLogger(__name__)
+
+REFRESH_SCHEDULE_ID = "daily-price-refresh"
+_DATA_FRESHNESS_WINDOW_HOURS = 24
+_ERROR_VOLUME_FAIL_THRESHOLD = 100
+
+
+def _result(name: str, status: str, summary: str, detail: dict | None = None) -> CheckResult:
+    return {"name": name, "status": status, "summary": summary, "detail": detail}
+
+
+def _rollup(checks: list[CheckResult]) -> str:
+    statuses = {c["status"] for c in checks}
+    if "fail" in statuses:
+        return "fail"
+    if "warn" in statuses:
+        return "warn"
+    if statuses == {"unknown"}:
+        return "unknown"
+    return "ok"
+
+
+async def _check_database() -> CheckResult:
+    try:
+        async with AsyncSessionLocal() as session:
+            await session.execute(text("SELECT 1"))
+        return _result("database", "ok", "Postgres reachable")
+    except Exception as exc:
+        return _result("database", "fail", f"Postgres unreachable: {exc}")
+
+
+async def _check_redis() -> CheckResult:
+    try:
+        await redis_client.ping()
+        return _result("redis", "ok", "Redis reachable")
+    except Exception as exc:
+        return _result("redis", "fail", f"Redis unreachable: {exc}")
+
+
+def _check_temporal(client: Client | None) -> CheckResult:
+    if client is None:
+        return _result("temporal", "fail", "Temporal unreachable")
+    return _result("temporal", "ok", "Temporal reachable")
+
+
+async def _check_data_freshness() -> CheckResult:
+    try:
+        cutoff = datetime.now(UTC) - timedelta(hours=_DATA_FRESHNESS_WINDOW_HOURS)
+        async with AsyncSessionLocal() as session:
+            count = (
+                await session.execute(
+                    select(func.count())
+                    .select_from(PriceSnapshot)
+                    .where(PriceSnapshot.created_at >= cutoff)
+                )
+            ).scalar_one()
+        detail = {"snapshots_24h": count}
+        if count == 0:
+            return _result(
+                "data_freshness",
+                "fail",
+                "No price snapshots in the last 24h — the refresh may not be running",
+                detail,
+            )
+        return _result("data_freshness", "ok", f"{count} price snapshots in the last 24h", detail)
+    except Exception as exc:
+        return _result("data_freshness", "fail", f"Snapshot query failed: {exc}")
+
+
+async def _check_failed_trips() -> CheckResult:
+    try:
+        async with AsyncSessionLocal() as session:
+            errored = (
+                await session.execute(
+                    select(func.count())
+                    .select_from(Trip)
+                    .where(Trip.status == TripStatus.ERROR)
+                )
+            ).scalar_one()
+            active = (
+                await session.execute(
+                    select(func.count())
+                    .select_from(Trip)
+                    .where(Trip.status == TripStatus.ACTIVE)
+                )
+            ).scalar_one()
+        detail = {"error": errored, "active": active}
+        if errored:
+            return _result("failed_trips", "warn", f"{errored} trip(s) in ERROR status", detail)
+        return _result("failed_trips", "ok", f"No errored trips ({active} active)", detail)
+    except Exception as exc:
+        return _result("failed_trips", "fail", f"Trip status query failed: {exc}")
+
+
+async def _check_notifications() -> CheckResult:
+    try:
+        async with AsyncSessionLocal() as session:
+            failed = (
+                await session.execute(
+                    select(func.count())
+                    .select_from(NotificationOutbox)
+                    .where(NotificationOutbox.status == NotificationStatus.FAILED)
+                )
+            ).scalar_one()
+            pending = (
+                await session.execute(
+                    select(func.count())
+                    .select_from(NotificationOutbox)
+                    .where(NotificationOutbox.status == NotificationStatus.PENDING)
+                )
+            ).scalar_one()
+        detail = {"failed": failed, "pending": pending}
+        if failed:
+            return _result(
+                "notifications", "warn", f"{failed} notification(s) failed to send", detail
+            )
+        return _result(
+            "notifications", "ok", f"No failed notifications ({pending} pending)", detail
+        )
+    except Exception as exc:
+        return _result("notifications", "fail", f"Outbox query failed: {exc}")
+
+
+async def _check_budget(name: str, metric: str, limit: int, label: str) -> CheckResult:
+    try:
+        day = datetime.now(UTC).strftime("%Y%m%d")
+        raw = await redis_client.get(CacheKeys.global_budget(metric, day))
+        used = int(raw) if raw else 0
+        pct = (used / limit * 100) if limit else 0.0
+        detail = {"used": used, "limit": limit, "pct": round(pct, 1)}
+        summary = f"{label}: {used:,}/{limit:,} ({pct:.0f}%) today"
+        if limit and used >= limit:
+            return _result(name, "fail", f"{summary} — breaker tripped", detail)
+        if pct >= 80:
+            return _result(name, "warn", summary, detail)
+        return _result(name, "ok", summary, detail)
+    except Exception as exc:
+        return _result(name, "unknown", f"{label} budget read failed: {exc}")
+
+
+async def _check_refresh_run(client: Client | None) -> CheckResult:
+    if client is None:
+        return _result("refresh_run", "unknown", "Temporal unreachable — schedule history unread")
+    try:
+        handle = client.get_schedule_handle(REFRESH_SCHEDULE_ID)
+        desc = await handle.describe()
+        actions = desc.info.recent_actions
+        if not actions:
+            return _result("refresh_run", "warn", "No recorded refresh runs yet")
+        last = actions[-1]
+        wf = client.get_workflow_handle(
+            last.action.workflow_id, run_id=last.action.first_execution_run_id
+        )
+        wf_desc = await wf.describe()
+        status_name = wf_desc.status.name if wf_desc.status else "UNKNOWN"
+        detail: dict = {"workflow_id": last.action.workflow_id, "status": status_name}
+        if status_name == "COMPLETED":
+            try:
+                result = await wf.result()
+                if isinstance(result, dict):
+                    detail.update(result)
+                    failed = result.get("users_failed", 0)
+                    if failed:
+                        return _result(
+                            "refresh_run",
+                            "warn",
+                            f"Last refresh completed with {failed} user failure(s)",
+                            detail,
+                        )
+                    return _result(
+                        "refresh_run",
+                        "ok",
+                        f"Last refresh OK ({result.get('users_successful', 0)}/"
+                        f"{result.get('users_total', 0)} users)",
+                        detail,
+                    )
+            except Exception:  # pragma: no cover - result fetch best-effort
+                pass
+            return _result("refresh_run", "ok", "Last refresh completed", detail)
+        if status_name == "RUNNING":
+            return _result("refresh_run", "ok", "Refresh currently running", detail)
+        if status_name in {"FAILED", "TERMINATED", "TIMED_OUT", "CANCELED"}:
+            return _result("refresh_run", "fail", f"Last refresh {status_name}", detail)
+        return _result("refresh_run", "warn", f"Last refresh status: {status_name}", detail)
+    except Exception as exc:
+        return _result("refresh_run", "unknown", f"Schedule history read failed: {exc}")
+
+
+async def _check_error_volume() -> CheckResult:
+    if not settings.axiom_query_enabled:
+        return _result("error_volume", "unknown", "Axiom query token unset — skipped")
+    apl = (
+        f'["{settings.axiom_dataset}"] '
+        '| where _time > ago(24h) and level == "error" | count'
+    )
+    count = await query_count(apl)
+    if count is None:
+        return _result("error_volume", "unknown", "Axiom query failed")
+    detail = {"errors_24h": count}
+    if count >= _ERROR_VOLUME_FAIL_THRESHOLD:
+        return _result("error_volume", "fail", f"{count} error logs in the last 24h", detail)
+    if count > 0:
+        return _result("error_volume", "warn", f"{count} error logs in the last 24h", detail)
+    return _result("error_volume", "ok", "No error logs in the last 24h", detail)
+
+
+async def _connect_temporal() -> Client | None:
+    try:
+        return await Client.connect(
+            settings.temporal_address, namespace=settings.temporal_namespace
+        )
+    except Exception as exc:
+        logger.warning(
+            "Health check could not connect to Temporal",
+            exc_info=exc,
+            extra={"event": "health.check.temporal.connect_failed"},
+        )
+        return None
+
+
+@activity.defn
+async def run_health_check_activity() -> dict:
+    """Run all health checks, roll up status, and email the digest to ADMIN_EMAILS."""
+    now = datetime.now(UTC)
+    temporal_client = await _connect_temporal()
+
+    checks: list[CheckResult] = list(
+        await asyncio.gather(
+            _check_database(),
+            _check_redis(),
+            _check_data_freshness(),
+            _check_failed_trips(),
+            _check_notifications(),
+            _check_budget(
+                "groq_budget", "groq_tokens", settings.global_daily_groq_token_budget, "Groq tokens"
+            ),
+            _check_budget(
+                "skiplagged_budget",
+                "skiplagged_calls",
+                settings.global_daily_skiplagged_call_budget,
+                "Skiplagged calls",
+            ),
+            _check_refresh_run(temporal_client),
+            _check_error_volume(),
+        )
+    )
+    checks.insert(2, _check_temporal(temporal_client))
+
+    status = _rollup(checks)
+    counts = {s: sum(1 for c in checks if c["status"] == s) for s in ("ok", "warn", "fail", "unknown")}
+
+    try:
+        async with AsyncSessionLocal() as session:
+            flags = await list_feature_flags(session)
+    except Exception:  # pragma: no cover - informational only
+        flags = []
+
+    recipients = settings.admin_emails_list
+    sent = 0
+    if not recipients:
+        logger.info(
+            "Health check complete (%s); email skipped — no ADMIN_EMAILS",
+            status,
+            extra={"event": "health.check.summary", "status": status, **counts, "sent": 0},
+        )
+        return {"status": status, "sent": 0, "skipped": True, **counts}
+
+    subject, html = render_health_digest(
+        status=status,
+        checks=checks,
+        flags=flags,
+        run_at=now.strftime("%Y-%m-%d %H:%M UTC"),
+        app_url=settings.frontend_url.rstrip("/"),
+    )
+    try:
+        await ResendClient().send(
+            to=recipients,
+            subject=subject,
+            html=html,
+            idempotency_key=f"health-summary-{now.strftime('%Y%m%d')}",
+        )
+        sent = len(recipients)
+    except EmailError as exc:
+        logger.error(
+            "Health digest send failed",
+            exc_info=exc,
+            extra={"event": "health.check.email.failed"},
+        )
+
+    logger.info(
+        "Health check complete (%s)",
+        status,
+        extra={"event": "health.check.summary", "status": status, **counts, "sent": sent},
+    )
+    return {"status": status, "sent": sent, "skipped": False, **counts}

--- a/apps/worker/worker/activities/health_check.py
+++ b/apps/worker/worker/activities/health_check.py
@@ -14,7 +14,7 @@ import logging
 from datetime import UTC, datetime, timedelta
 
 from app.clients.axiom_query import query_count
-from app.clients.email import EmailError, ResendClient
+from app.clients.email import ResendClient
 from app.core.cache_keys import CacheKeys
 from app.core.config import settings
 from app.core.constants import NotificationStatus, TripStatus
@@ -221,6 +221,7 @@ async def _check_refresh_run(client: Client | None) -> CheckResult:
 async def _check_error_volume() -> CheckResult:
     if not settings.axiom_query_enabled:
         return _result("error_volume", "unknown", "Axiom query token unset — skipped")
+    # axiom_dataset is trusted operator config (env), not user input — safe to interpolate.
     apl = (
         f'["{settings.axiom_dataset}"] '
         '| where _time > ago(24h) and level == "error" | count'
@@ -297,14 +298,17 @@ async def run_health_check_activity() -> dict:
         )
         return {"status": status, "sent": 0, "skipped": True, **counts}
 
-    subject, html = render_health_digest(
-        status=status,
-        checks=checks,
-        flags=flags,
-        run_at=now.strftime("%Y-%m-%d %H:%M UTC"),
-        app_url=settings.frontend_url.rstrip("/"),
-    )
+    # Render + send inside one guard so a template regression (or any send
+    # failure) is logged rather than thrown — the activity must never fail the
+    # workflow over the email itself.
     try:
+        subject, html = render_health_digest(
+            status=status,
+            checks=checks,
+            flags=flags,
+            run_at=now.strftime("%Y-%m-%d %H:%M UTC"),
+            app_url=settings.frontend_url.rstrip("/"),
+        )
         await ResendClient().send(
             to=recipients,
             subject=subject,
@@ -312,9 +316,9 @@ async def run_health_check_activity() -> dict:
             idempotency_key=f"health-summary-{now.strftime('%Y%m%d')}",
         )
         sent = len(recipients)
-    except EmailError as exc:
+    except Exception as exc:
         logger.error(
-            "Health digest send failed",
+            "Health digest render/send failed",
             exc_info=exc,
             extra={"event": "health.check.email.failed"},
         )

--- a/apps/worker/worker/schedule_bootstrap.py
+++ b/apps/worker/worker/schedule_bootstrap.py
@@ -18,19 +18,54 @@ SCHEDULE_ID = "daily-price-refresh"
 WORKFLOW_NAME = "ScheduledRefreshAllUsersWorkflow"
 WORKFLOW_ID = "scheduled-refresh-all-users"
 
+HEALTH_SCHEDULE_ID = "daily-health-check"
+HEALTH_WORKFLOW_NAME = "RunHealthCheckWorkflow"
+HEALTH_WORKFLOW_ID = "daily-health-check-run"
+
 logger = logging.getLogger(__name__)
 
 
-def _build_schedule() -> Schedule:
+def _build_schedule(workflow_name: str, workflow_id: str, cron: str) -> Schedule:
     return Schedule(
         action=ScheduleActionStartWorkflow(
-            WORKFLOW_NAME,
-            id=WORKFLOW_ID,
+            workflow_name,
+            id=workflow_id,
             task_queue=settings.temporal_task_queue,
         ),
-        spec=ScheduleSpec(cron_expressions=[settings.daily_refresh_cron]),
+        spec=ScheduleSpec(cron_expressions=[cron]),
         policy=SchedulePolicy(overlap=ScheduleOverlapPolicy.SKIP),
     )
+
+
+async def _create_or_update_schedule(
+    client: Client, schedule_id: str, schedule: Schedule, cron: str
+) -> str:
+    """Idempotently create the schedule, or update it if it already exists."""
+    try:
+        await client.create_schedule(schedule_id, schedule)
+        logger.info(
+            "Created schedule %s with cron %r",
+            schedule_id,
+            cron,
+            extra={"event": "schedule.bootstrap.ok", "schedule_id": schedule_id, "cron": str(cron)},
+        )
+        return "created"
+    except ScheduleAlreadyRunningError:
+        pass
+
+    handle = client.get_schedule_handle(schedule_id)
+
+    def _updater(_input: ScheduleUpdateInput) -> ScheduleUpdate:
+        return ScheduleUpdate(schedule=schedule)
+
+    await handle.update(_updater)
+    logger.info(
+        "Updated schedule %s with cron %r",
+        schedule_id,
+        cron,
+        extra={"event": "schedule.bootstrap.exists", "schedule_id": schedule_id, "cron": str(cron)},
+    )
+    return "updated"
 
 
 @observe(name="worker.ensure_daily_refresh_schedule")
@@ -47,34 +82,32 @@ async def ensure_daily_refresh_schedule(client: Client) -> None:
             "task_queue": settings.temporal_task_queue,
         },
     )
-    schedule = _build_schedule()
-    try:
-        await client.create_schedule(SCHEDULE_ID, schedule)
-        logger.info(
-            "Created schedule %s with cron %r", SCHEDULE_ID, settings.daily_refresh_cron,
-            extra={
-                "event": "schedule.bootstrap.ok",
-                "schedule_id": SCHEDULE_ID,
-                "cron": str(settings.daily_refresh_cron),
-            },
-        )
-        langfuse_context.update_current_observation(output={"action": "created"})
-        return
-    except ScheduleAlreadyRunningError:
-        pass
+    schedule = _build_schedule(WORKFLOW_NAME, WORKFLOW_ID, settings.daily_refresh_cron)
+    action = await _create_or_update_schedule(
+        client, SCHEDULE_ID, schedule, settings.daily_refresh_cron
+    )
+    langfuse_context.update_current_observation(output={"action": action})
 
-    handle = client.get_schedule_handle(SCHEDULE_ID)
 
-    def _updater(_input: ScheduleUpdateInput) -> ScheduleUpdate:
-        return ScheduleUpdate(schedule=schedule)
-
-    await handle.update(_updater)
-    logger.info(
-        "Updated schedule %s with cron %r", SCHEDULE_ID, settings.daily_refresh_cron,
-        extra={
-            "event": "schedule.bootstrap.exists",
-            "schedule_id": SCHEDULE_ID,
-            "cron": str(settings.daily_refresh_cron),
+@observe(name="worker.ensure_daily_health_schedule")
+async def ensure_daily_health_schedule(client: Client) -> None:
+    """Create/update the daily system-health digest schedule (idempotent)."""
+    langfuse_context.update_current_trace(
+        name="schedule_bootstrap",
+        tags=["worker", "schedule_bootstrap"],
+    )
+    langfuse_context.update_current_observation(
+        input={
+            "schedule_id": HEALTH_SCHEDULE_ID,
+            "workflow_name": HEALTH_WORKFLOW_NAME,
+            "cron": settings.daily_health_cron,
+            "task_queue": settings.temporal_task_queue,
         },
     )
-    langfuse_context.update_current_observation(output={"action": "updated"})
+    schedule = _build_schedule(
+        HEALTH_WORKFLOW_NAME, HEALTH_WORKFLOW_ID, settings.daily_health_cron
+    )
+    action = await _create_or_update_schedule(
+        client, HEALTH_SCHEDULE_ID, schedule, settings.daily_health_cron
+    )
+    langfuse_context.update_current_observation(output={"action": action})

--- a/apps/worker/worker/workflows/health_check.py
+++ b/apps/worker/worker/workflows/health_check.py
@@ -1,0 +1,22 @@
+from datetime import timedelta
+
+from temporalio import workflow
+from temporalio.common import RetryPolicy
+
+with workflow.unsafe.imports_passed_through():
+    # Pulls in the email/render/axiom/db stack; keep it passed through so the
+    # workflow sandbox doesn't re-import those modules.
+    from worker.activities.health_check import run_health_check_activity
+
+
+@workflow.defn
+class RunHealthCheckWorkflow:
+    @workflow.run
+    async def run(self) -> dict:
+        return await workflow.execute_activity(
+            run_health_check_activity,
+            start_to_close_timeout=timedelta(seconds=120),
+            # The activity catches its own errors and is idempotent (Resend
+            # collapses same-key sends within 24h), so a single retry is safe.
+            retry_policy=RetryPolicy(maximum_attempts=2),
+        )


### PR DESCRIPTION
## Summary

- Adds a **daily system-health digest** email (showbook's `runHealthCheck` analog): a new `RunHealthCheckWorkflow` on a `DAILY_HEALTH_CRON` (default `0 7 * * *`, one hour after the refresh) Temporal schedule that runs independent system checks **in parallel** and emails an ops summary to **`ADMIN_EMAILS`** via the existing `ResendClient`.
- Mirrors showbook faithfully (fetched from `health-check.ts` over HTTPS — the git protocol is egress-blocked): each check returns a `CheckResult{name, status: ok/warn/fail/unknown, summary}`, rolled up to an overall status; the activity **never throws** and skips sending when `ADMIN_EMAILS` / `RESEND_API_KEY` is unset. Subject mirrors `formatSubject`: `[VPT health] OK | FAIL — N… | WARN — N… | UNKNOWN`.
- **Checks:** DB / Redis / Temporal connectivity, snapshot freshness (24h), errored trips, notification-outbox failures, Groq + Skiplagged daily-budget usage vs the merged quota ceilings, the last scheduled-refresh outcome (via **Temporal history**), and **Axiom** error volume. The Axiom check reports `unknown` when `AXIOM_QUERY_TOKEN` is unset — via a new read-only `axiom_query` client (the ingest token can't query).
- Widens `ResendClient.send` to accept a recipient list; adds `ADMIN_EMAILS` / `DAILY_HEALTH_CRON` / `AXIOM_QUERY_TOKEN` / `AXIOM_ORG_ID` env vars; documents **both** daily cron schedules in `apps/worker/CLAUDE.md` + README.

Operator-managed, no feature flag, no DB migration. Inert until `ADMIN_EMAILS` is set (and dry-run until `RESEND_API_KEY` is set).

## Test plan

- [x] `pnpm verify` green (build, lint, typecheck, 95% coverage on api + worker, audits)
- [x] Worker unit tests for `run_health_check_activity`: sends to `ADMIN_EMAILS`; skips when unset; per-check failure paths (DB/Redis/Temporal down, no snapshots, errored trips, failed notifications, budget warn/fail, Axiom warn/fail/unknown); refresh-run from Temporal history (ok/warn/failed/running/no-actions); email failure swallowed (`health_check.py` at 98%)
- [x] `ensure_daily_health_schedule` unit test + `DAILY_HEALTH_CRON` parse test; existing refresh tests updated for the shared bootstrap helper
- [x] API tests: `render_health_digest` (OK/WARN/FAIL/UNKNOWN subjects) + `axiom_query` client (success / unconfigured→None / bad-shape→None)
- [x] Integration test (`WorkflowEnvironment.start_local()`) registers `RunHealthCheckWorkflow` in the real Temporal sandbox and runs the scheduled chain to completion — validates the workflow's passed-through imports
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CLU2qzji7MCM2UREz8yaZR

---
_Generated by [Claude Code](https://claude.ai/code/session_01Su1E2cUBahrfUT8H8PubHc)_