### PR TITLE
fix: treat zero-priced offers as unpriced, not a real $0

### DIFF
--- a/apps/api/app/routers/trips.py
+++ b/apps/api/app/routers/trips.py
@@ -1,4 +1,5 @@
 import uuid
+from decimal import Decimal, InvalidOperation
 
 from fastapi import APIRouter, Depends, Query, Response, status
 from sqlalchemy import func, select
@@ -152,7 +153,11 @@ def _extract_price(item: dict) -> str | None:
     if "price" in item:
         price_val = item["price"]
         if isinstance(price_val, dict):
-            return price_val.get("amount") or price_val.get("total")
+            # `amount` may legitimately be 0 — use an explicit None check so a
+            # zero price isn't silently swallowed by an `or` and mistaken for a
+            # missing one. `_coerce_positive_price` rejects the zero downstream.
+            amount = price_val.get("amount")
+            return amount if amount is not None else price_val.get("total")
         return str(price_val)
     if "total_price" in item:
         return str(item["total_price"])
@@ -163,6 +168,23 @@ def _extract_price(item: dict) -> str | None:
         if prices:
             return str(min(prices))
     return None
+
+
+def _coerce_positive_price(raw: object) -> Decimal | None:
+    """Coerce an extracted price to a positive Decimal, else None.
+
+    A missing, unparseable, zero, or negative price means the provider returned
+    an unpriced/degraded offer (e.g. Skiplagged occasionally returns itineraries
+    with ``amount: 0``). Such offers must not render as a real $0 fare, so they
+    are dropped from the offer list.
+    """
+    if raw is None:
+        return None
+    try:
+        value = Decimal(str(raw))
+    except (InvalidOperation, ValueError, TypeError):
+        return None
+    return value if value > 0 else None
 
 
 def _parse_skiplagged_trip_segments(flight_id: str) -> tuple[list[tuple[str, str]], list[tuple[str, str]]]:
@@ -190,7 +212,7 @@ def _parse_flight_offer(item: dict, index: int, flights_data: dict) -> FlightOff
     """
     if not isinstance(item, dict):
         return None
-    price = _extract_price(item)
+    price = _coerce_positive_price(_extract_price(item))
     if price is None:
         return None
 
@@ -306,7 +328,7 @@ def _parse_hotel_offer(item: dict, index: int) -> HotelOffer | None:
     """
     if not isinstance(item, dict):
         return None
-    price = _extract_price(item)
+    price = _coerce_positive_price(_extract_price(item))
     if price is None:
         return None
     # Description: concatenate room titles if present, else fallback to top-level fields

--- a/apps/api/app/routers/trips.py
+++ b/apps/api/app/routers/trips.py
@@ -156,6 +156,10 @@ def _extract_price(item: dict) -> str | None:
             # `amount` may legitimately be 0 — use an explicit None check so a
             # zero price isn't silently swallowed by an `or` and mistaken for a
             # missing one. `_coerce_positive_price` rejects the zero downstream.
+            # `amount` is authoritative: a present `amount` (even 0) intentionally
+            # shadows `total`; `total` is only the fallback when `amount` is
+            # absent. Don't "fix" this into an `amount or total` fallback — that
+            # reintroduces the falsy-zero bug this change exists to kill.
             amount = price_val.get("amount")
             return amount if amount is not None else price_val.get("total")
         return str(price_val)

--- a/apps/api/tests/test_trips.py
+++ b/apps/api/tests/test_trips.py
@@ -1003,6 +1003,70 @@ def test_extract_price_helper():
     # No rooms, no price
     assert trips_module._extract_price({"name": "Test Hotel"}) is None
 
+    # A zero `amount` must not be swallowed by the old `amount or total` idiom:
+    # it should be returned as 0 (and rejected later by _coerce_positive_price),
+    # not fall through to `total`.
+    assert trips_module._extract_price({"price": {"amount": 0}}) == 0
+    assert trips_module._extract_price({"price": {"amount": 0, "total": 250}}) == 0
+
+
+def test_coerce_positive_price_rejects_non_positive():
+    """Zero / negative / unparseable prices are treated as missing."""
+    assert trips_module._coerce_positive_price(0) is None
+    assert trips_module._coerce_positive_price("0") is None
+    assert trips_module._coerce_positive_price("0.00") is None
+    assert trips_module._coerce_positive_price(-5) is None
+    assert trips_module._coerce_positive_price(None) is None
+    assert trips_module._coerce_positive_price("not-a-number") is None
+    assert trips_module._coerce_positive_price("177") == Decimal("177")
+    assert trips_module._coerce_positive_price(399.99) == Decimal("399.99")
+
+
+def test_snapshot_to_response_drops_zero_priced_offers(test_session):
+    """Degraded provider responses (amount: 0) must not render as $0 offers.
+
+    Regression for the SFO->RDM trip where Skiplagged returned three flights all
+    priced 0; the old `amount or total` extraction dropped them via a falsy 0,
+    and the worker stored a misleading $0. The trip-detail response must expose
+    zero flight/hotel offers for such data.
+    """
+    snapshot = PriceSnapshot(
+        id=uuid.uuid4(),
+        trip_id=uuid.uuid4(),
+        flight_price=None,
+        hotel_price=None,
+        total_price=None,
+        created_at=datetime.now(UTC),
+        raw_data={
+            "flights": {
+                "data": [
+                    {
+                        "id": "SFO-RDM-2026-08-22-2026-08-26-trip=AS3361,AS3360",
+                        "airlines": "Alaska Airlines",
+                        "carrier_code": "AS",
+                        "price": {"amount": 0, "currency": "USD"},
+                    },
+                    {
+                        "id": "SFO-RDM-2026-08-22-2026-08-26-trip=UA670,UA702",
+                        "airlines": "United Airlines",
+                        "carrier_code": "UA",
+                        "price": {"amount": 0, "currency": "USD"},
+                    },
+                ],
+            },
+            "hotels": {
+                "data": [
+                    {"id": "h1", "name": "Zero Inn", "price": {"amount": 0}},
+                ]
+            },
+        },
+    )
+
+    response = trips_module._snapshot_to_response(snapshot)
+
+    assert response.flight_offers == []
+    assert response.hotel_offers == []
+
 
 def test_snapshot_to_response_with_skiplagged_data(test_session):
     """Test _snapshot_to_response extracts Skiplagged-shaped flight and hotel data."""

--- a/apps/web/src/__tests__/lib/price-history.test.ts
+++ b/apps/web/src/__tests__/lib/price-history.test.ts
@@ -86,9 +86,28 @@ describe("aggregateDailyPriceHistory", () => {
     expect(result.map((r) => r.label)).toEqual(["Jul 15", "Jul 16", "Jul 17"]);
   });
 
-  it("treats missing prices as zero", () => {
+  it("drops a degraded snapshot with no priced component (no fake $0 point)", () => {
+    // Both prices null = a degraded provider response (only unpriced/$0 offers).
+    // It must not plot a misleading $0 point.
     const result = aggregateDailyPriceHistory([snapshot({ created_at: "2026-01-05T10:00:00Z" })]);
-    expect(result[0]).toMatchObject({ minFlight: 0, minHotel: 0, total: 0, label: "Jan 5" });
+    expect(result).toEqual([]);
+  });
+
+  it("keeps a snapshot with only one priced component", () => {
+    // Flights-only trip: hotel price absent should count as 0, not drop the day.
+    const result = aggregateDailyPriceHistory([
+      snapshot({ created_at: "2026-01-05T10:00:00Z", flight_price: "175" }),
+    ]);
+    expect(result[0]).toMatchObject({ minFlight: 175, minHotel: 0, total: 175, label: "Jan 5" });
+  });
+
+  it("does not let a degraded snapshot displace a priced one on the same day", () => {
+    const result = aggregateDailyPriceHistory([
+      snapshot({ created_at: "2026-01-05T09:00:00Z", flight_price: "175", hotel_price: "120" }),
+      snapshot({ created_at: "2026-01-05T18:00:00Z" }), // degraded, would be $0
+    ]);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({ minFlight: 175, minHotel: 120, total: 295 });
   });
 
   it("carries the selected hotel price forward across a gap day", () => {

--- a/apps/web/src/app/trips/[tripId]/page.tsx
+++ b/apps/web/src/app/trips/[tripId]/page.tsx
@@ -110,7 +110,16 @@ function PriceHistoryChart({
   selectedFlightLabel?: string;
   showHotel?: boolean;
 }) {
-  if (priceHistory.length === 0) {
+  // Collapse to one point per calendar day (cheapest total that day) so long
+  // tracking windows stay readable. Carry-forward for selected offers is handled
+  // inside aggregateDailyPriceHistory. Degraded snapshots (no priced offers) are
+  // dropped here, so this can be empty even when priceHistory has rows.
+  const chartData = aggregateDailyPriceHistory(priceHistory, {
+    selectedFlightKey,
+    selectedHotelKey,
+  });
+
+  if (chartData.length === 0) {
     return (
       <div className={styles.emptyChart}>
         <TrendingUp className={styles.emptyChartIcon} />
@@ -118,14 +127,6 @@ function PriceHistoryChart({
       </div>
     );
   }
-
-  // Collapse to one point per calendar day (cheapest total that day) so long
-  // tracking windows stay readable. Carry-forward for selected offers is handled
-  // inside aggregateDailyPriceHistory.
-  const chartData = aggregateDailyPriceHistory(priceHistory, {
-    selectedFlightKey,
-    selectedHotelKey,
-  });
 
   const selectedFlightLineLabel = selectedFlightLabel ?? "Selected Flight";
   const selectedHotelLineLabel = selectedHotelLabel ?? "Selected Hotel";

--- a/apps/web/src/lib/price-history.ts
+++ b/apps/web/src/lib/price-history.ts
@@ -86,10 +86,13 @@ interface AggregateOptions {
   selectedHotelKey?: string | null;
 }
 
-const snapshotTotal = (snapshot: PriceSnapshot): number => {
-  const minFlight = parsePrice(snapshot.flight_price) ?? 0;
-  const minHotel = parsePrice(snapshot.hotel_price) ?? 0;
-  return minFlight + minHotel;
+const snapshotTotal = (snapshot: PriceSnapshot): number | null => {
+  const minFlight = parsePrice(snapshot.flight_price);
+  const minHotel = parsePrice(snapshot.hotel_price);
+  // No priced component at all (e.g. a degraded provider response with only
+  // unpriced/$0 offers) is not a real $0 total — signal "nothing to plot".
+  if (minFlight === null && minHotel === null) return null;
+  return (minFlight ?? 0) + (minHotel ?? 0);
 };
 
 /**
@@ -115,8 +118,13 @@ export function aggregateDailyPriceHistory(
   for (const snapshot of priceHistory) {
     const day = snapshot.created_at.slice(0, 10);
     if (!day) continue;
+    const total = snapshotTotal(snapshot);
+    // Skip degraded snapshots (no priced offers) so they neither plot a fake $0
+    // point nor displace a genuinely-priced snapshot as the day's cheapest.
+    if (total === null) continue;
     const existing = cheapestByDay.get(day);
-    if (!existing || snapshotTotal(snapshot) < snapshotTotal(existing)) {
+    const existingTotal = existing ? snapshotTotal(existing) : null;
+    if (existingTotal === null || total < existingTotal) {
       cheapestByDay.set(day, snapshot);
     }
   }

--- a/apps/worker/tests/test_price_check_activities.py
+++ b/apps/worker/tests/test_price_check_activities.py
@@ -584,6 +584,48 @@ def test_filter_helpers_and_price_extraction():
     assert pc._extract_min_price([nested_hotel]) == Decimal("289.00")
     # No offers array
     assert pc._extract_price_value({"hotel": {"name": "Test"}}) is None
+    # Zero / non-positive prices are unpriced offers, not a real $0 fare: they
+    # are excluded from both the min-price and the priced count.
+    zero_priced = [
+        {"price": {"amount": 0, "currency": "USD"}},
+        {"price": {"amount": 0, "currency": "USD"}},
+    ]
+    assert pc._extract_min_price(zero_priced) is None
+    assert pc._priced_values(zero_priced) == []
+    mixed = [{"price": "0"}, {"price": "175"}, {"price": "210"}]
+    assert pc._extract_min_price(mixed) == Decimal("175")
+    assert pc._priced_values(mixed) == [Decimal("175"), Decimal("210")]
+
+
+@pytest.mark.asyncio
+async def test_save_snapshot_activity_all_zero_prices_stores_null(monkeypatch):
+    """Degraded provider response (all flights priced 0) must not become a $0
+    snapshot: price stays None and the offers are marked as unpriced.
+
+    Regression for the SFO->RDM trip whose refresh stored flight_price=0.00.
+    """
+    trip_id = str(uuid.uuid4())
+    session = DummySessionWithDedup(None, [], recent_snapshot=None)
+    monkeypatch.setattr(pc, "AsyncSessionLocal", lambda: DummySessionManagerWithDedup(session))
+
+    payload = {
+        "trip_id": trip_id,
+        "flights": [
+            {"id": "SFO-RDM-trip=AS3361,AS3360", "price": {"amount": 0, "currency": "USD"}},
+            {"id": "SFO-RDM-trip=UA670,UA702", "price": {"amount": 0, "currency": "USD"}},
+        ],
+        "hotels": [],
+        "raw_data": {"ok": True},
+    }
+
+    snapshot_id = await pc.save_snapshot_activity(payload)
+
+    assert snapshot_id
+    assert session.added.flight_price is None
+    assert session.added.total_price is None
+    raw_flights = session.added.raw_data["flights"]
+    assert raw_flights["priced_count"] == 0
+    assert raw_flights["unpriced_count"] == 2
 
 
 # ---------------------------------------------------------------------------

--- a/apps/worker/tests/test_price_check_activities.py
+++ b/apps/worker/tests/test_price_check_activities.py
@@ -599,8 +599,8 @@ def test_filter_helpers_and_price_extraction():
 
 @pytest.mark.asyncio
 async def test_save_snapshot_activity_all_zero_prices_stores_null(monkeypatch):
-    """Degraded provider response (all flights priced 0) must not become a $0
-    snapshot: price stays None and the offers are marked as unpriced.
+    """Degraded provider response (all flights AND hotels priced 0) must not
+    become a $0 snapshot: prices stay None and the offers are marked as unpriced.
 
     Regression for the SFO->RDM trip whose refresh stored flight_price=0.00.
     """
@@ -614,7 +614,9 @@ async def test_save_snapshot_activity_all_zero_prices_stores_null(monkeypatch):
             {"id": "SFO-RDM-trip=AS3361,AS3360", "price": {"amount": 0, "currency": "USD"}},
             {"id": "SFO-RDM-trip=UA670,UA702", "price": {"amount": 0, "currency": "USD"}},
         ],
-        "hotels": [],
+        "hotels": [
+            {"id": "h1", "name": "Zero Inn", "price": {"amount": 0, "currency": "USD"}},
+        ],
         "raw_data": {"ok": True},
     }
 
@@ -622,10 +624,14 @@ async def test_save_snapshot_activity_all_zero_prices_stores_null(monkeypatch):
 
     assert snapshot_id
     assert session.added.flight_price is None
+    assert session.added.hotel_price is None
     assert session.added.total_price is None
     raw_flights = session.added.raw_data["flights"]
     assert raw_flights["priced_count"] == 0
     assert raw_flights["unpriced_count"] == 2
+    raw_hotels = session.added.raw_data["hotels"]
+    assert raw_hotels["priced_count"] == 0
+    assert raw_hotels["unpriced_count"] == 1
 
 
 # ---------------------------------------------------------------------------

--- a/apps/worker/worker/activities/price_check.py
+++ b/apps/worker/worker/activities/price_check.py
@@ -508,8 +508,41 @@ async def save_snapshot_activity(payload: SaveSnapshotInput) -> str:
                 return str(recent_snapshot.id)
 
         # Proceed with normal snapshot creation
-        flight_price = _extract_min_price(payload["flights"])
-        hotel_price = _extract_min_price(payload["hotels"])
+        flight_items = payload["flights"]
+        hotel_items = payload["hotels"]
+        flight_price = _extract_min_price(flight_items)
+        hotel_price = _extract_min_price(hotel_items)
+        flight_priced = len(_priced_values(flight_items))
+        hotel_priced = len(_priced_values(hotel_items))
+
+        # A provider can return results that all carry a 0/unpriced amount
+        # (degraded response). Persist the snapshot with a null price rather than
+        # a misleading $0 fare, and surface the degradation so a daily/manual
+        # retry can recover it. The marker counts let the API/UI tell "no offers"
+        # apart from "offers came back but none were priced".
+        if flight_items and flight_price is None:
+            logger.warning(
+                "Provider returned %d flight result(s) for trip_id=%s but none were priced",
+                len(flight_items),
+                payload["trip_id"],
+                extra={
+                    "event": "activity.save_snapshot.no_priced_flights",
+                    "trip_id": payload["trip_id"],
+                    "result_count": len(flight_items),
+                },
+            )
+        if hotel_items and hotel_price is None:
+            logger.warning(
+                "Provider returned %d hotel result(s) for trip_id=%s but none were priced",
+                len(hotel_items),
+                payload["trip_id"],
+                extra={
+                    "event": "activity.save_snapshot.no_priced_hotels",
+                    "trip_id": payload["trip_id"],
+                    "result_count": len(hotel_items),
+                },
+            )
+
         # Calculate total from whatever prices are available
         total_price = None
         if flight_price is not None or hotel_price is not None:
@@ -531,10 +564,14 @@ async def save_snapshot_activity(payload: SaveSnapshotInput) -> str:
 
         raw_data = dict(payload["raw_data"] or {})
         raw_flights = dict(raw_data.get("flights") or {})
-        raw_flights["data"] = payload["flights"]
+        raw_flights["data"] = flight_items
+        raw_flights["priced_count"] = flight_priced
+        raw_flights["unpriced_count"] = len(flight_items) - flight_priced
         raw_data["flights"] = raw_flights
         raw_hotels = dict(raw_data.get("hotels") or {})
-        raw_hotels["data"] = payload["hotels"]
+        raw_hotels["data"] = hotel_items
+        raw_hotels["priced_count"] = hotel_priced
+        raw_hotels["unpriced_count"] = len(hotel_items) - hotel_priced
         raw_data["hotels"] = raw_hotels
 
         snapshot = PriceSnapshot(
@@ -699,12 +736,23 @@ def _matches_view(description: Any, views: list[str]) -> bool:
 
 
 def _extract_min_price(items: list[dict[str, Any]]) -> Decimal | None:
-    prices: list[Decimal] = []
-    for item in items:
-        value = _extract_price_value(item)
-        if value is not None:
-            prices.append(value)
+    prices = _priced_values(items)
     return min(prices) if prices else None
+
+
+def _priced_values(items: list[dict[str, Any]]) -> list[Decimal]:
+    """Return the strictly-positive prices among the given offers.
+
+    A price of 0 (or negative) means the provider returned an unpriced/degraded
+    offer — Skiplagged occasionally returns itineraries with ``amount: 0``. These
+    must not be counted as a real $0 fare, so they are excluded from both the
+    minimum-price calculation and the priced-offer count.
+    """
+    return [
+        value
+        for item in items
+        if (value := _extract_price_value(item)) is not None and value > 0
+    ]
 
 
 def _extract_from_fields(obj: dict[str, Any]) -> Decimal | None:


### PR DESCRIPTION
## Summary

- **Root cause:** Skiplagged occasionally returns itineraries with `price.amount = 0` (a degraded/unpriced response). A real SFO→RDM trip refresh hit this — the provider returned 3 flights all priced `$0` — and three layers each mishandled it, producing the confusing "FLIGHT $0" header **and** an empty "No flight offers available" card on the same data. (Live Skiplagged returns 70 priced flights for this route; the $0 state was transient, but our code shouldn't persist/show it.)
- **worker (`apps/worker/.../price_check.py`):** `_extract_min_price` counted `0` as a valid fare, so the refresh stored `flight_price = 0.00`. It now ignores non-positive prices (`_priced_values`); when results come back but none are priced, it persists a **null** price (not `$0`), records `priced_count`/`unpriced_count` markers in `raw_data`, and logs a warning so a daily/manual retry can recover.
- **api (`apps/api/app/routers/trips.py`):** `_extract_price` used `amount or total`, so a falsy `0` fell through to `None` and silently dropped the offer. It now uses an explicit `None` check, and both offer parsers run prices through `_coerce_positive_price`, which rejects missing/zero/negative values — so a degraded snapshot cleanly yields zero offers instead of contradicting the header.
- **web (`apps/web/src/lib/price-history.ts`, `trips/[tripId]/page.tsx`):** the chart coerced null prices to `0`, plotting a fake `$0` point and letting a degraded snapshot displace a genuinely-priced one as the day's cheapest. Degraded snapshots are now skipped, and the chart shows its empty state when nothing is plottable.

## Test plan

- [x] `apps/api` — new `test_coerce_positive_price_rejects_non_positive` + `test_snapshot_to_response_drops_zero_priced_offers`; extended `_extract_price` zero-case asserts
- [x] `apps/worker` — `_extract_min_price`/`_priced_values` ignore non-positive; new `test_save_snapshot_activity_all_zero_prices_stores_null` (null price + markers)
- [x] `apps/web` — price-history: degraded snapshot dropped, one-sided price kept, degraded doesn't displace priced
- [x] `pnpm verify` green (api 96.6% / worker 97% coverage, lint, typecheck, build, audits)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CLU2qzji7MCM2UREz8yaZR

---
_Generated by [Claude Code](https://claude.ai/code/session_015cwzPiyQfJKxYUhR6oCbfa)_