### PR TITLE
fix(api): serialize DB-native types in /v1/admin/sql results

### DIFF
--- a/apps/api/app/routers/admin.py
+++ b/apps/api/app/routers/admin.py
@@ -35,6 +35,7 @@ from __future__ import annotations
 import hmac
 import json
 import logging
+import math
 import time
 from collections.abc import AsyncGenerator
 from datetime import date, datetime
@@ -71,8 +72,10 @@ def _json_default(obj: object) -> object:
     cannot encode. Because the response is rendered *after* the handler's
     try/except, such a ``TypeError`` would escape as an opaque 500 (forcing
     callers to ``::text``-cast every date/numeric column). Coerce the known
-    types, and fall back to ``str()`` for anything else so no column type can
-    500 this debug endpoint again.
+    types, and fall back to ``str()`` for anything else. Non-finite floats
+    (``NaN``/``Infinity`` from a real/double column) are *not* routed here —
+    they are handled in :meth:`_RowsJSONResponse.render` — but between the two,
+    no column type can 500 this debug endpoint.
     """
     if isinstance(obj, (datetime, date, dtime)):
         return obj.isoformat()
@@ -85,17 +88,48 @@ def _json_default(obj: object) -> object:
     return str(obj)
 
 
+def _replace_non_finite_floats(obj: object) -> object:
+    """Recursively replace NaN/Infinity floats with None (valid JSON null).
+
+    A non-finite ``float`` (from a Postgres ``real``/``double precision``
+    column) is *not* passed to ``json.dumps``' ``default`` hook, so it can't be
+    coerced there; with ``allow_nan=False`` it raises ``ValueError``. We emit
+    ``null`` rather than flip ``allow_nan`` on, because ``NaN``/``Infinity`` are
+    not valid JSON and would break strict consumers (e.g. ``JSON.parse`` in
+    ``scripts/prod-query.mjs``).
+    """
+    if isinstance(obj, float):
+        return obj if math.isfinite(obj) else None
+    if isinstance(obj, dict):
+        return {k: _replace_non_finite_floats(v) for k, v in obj.items()}
+    if isinstance(obj, (list, tuple)):
+        return [_replace_non_finite_floats(v) for v in obj]
+    return obj
+
+
 class _RowsJSONResponse(JSONResponse):
     """JSONResponse that tolerates DB-native scalar types in row values."""
 
     def render(self, content: object) -> bytes:
-        return json.dumps(
-            content,
-            ensure_ascii=False,
-            allow_nan=False,
-            separators=(",", ":"),
-            default=_json_default,
-        ).encode("utf-8")
+        try:
+            return json.dumps(
+                content,
+                ensure_ascii=False,
+                allow_nan=False,
+                separators=(",", ":"),
+                default=_json_default,
+            ).encode("utf-8")
+        except ValueError:
+            # Only reachable when a non-finite float slipped in; retry with
+            # those replaced by null. Kept as a fallback so the common path
+            # pays no traversal cost.
+            return json.dumps(
+                _replace_non_finite_floats(content),
+                ensure_ascii=False,
+                allow_nan=False,
+                separators=(",", ":"),
+                default=_json_default,
+            ).encode("utf-8")
 
 
 # Lazily-created dedicated engine. Prefer ADMIN_QUERY_DATABASE_URL so prod can

--- a/apps/api/app/routers/admin.py
+++ b/apps/api/app/routers/admin.py
@@ -33,9 +33,14 @@ Defense in depth (deepest-first):
 from __future__ import annotations
 
 import hmac
+import json
 import logging
 import time
 from collections.abc import AsyncGenerator
+from datetime import date, datetime
+from datetime import time as dtime
+from decimal import Decimal
+from uuid import UUID
 
 from fastapi import APIRouter, Depends, Request
 from fastapi.responses import JSONResponse
@@ -55,6 +60,43 @@ STATEMENT_TIMEOUT_MS = 3000
 RATE_LIMIT_MAX = 30
 RATE_LIMIT_WINDOW_SECONDS = 60
 MIN_TOKEN_LENGTH = 32
+
+
+def _json_default(obj: object) -> object:
+    """Best-effort JSON coercion for DB-native types the stdlib encoder rejects.
+
+    The endpoint returns arbitrary query results, so a column typed
+    date / timestamp / numeric / uuid / bytea comes back as a Python
+    ``date``/``datetime``/``Decimal``/``UUID``/``bytes`` that ``json.dumps``
+    cannot encode. Because the response is rendered *after* the handler's
+    try/except, such a ``TypeError`` would escape as an opaque 500 (forcing
+    callers to ``::text``-cast every date/numeric column). Coerce the known
+    types, and fall back to ``str()`` for anything else so no column type can
+    500 this debug endpoint again.
+    """
+    if isinstance(obj, (datetime, date, dtime)):
+        return obj.isoformat()
+    if isinstance(obj, Decimal):
+        return str(obj)  # keep exact precision (prices); float would lose it
+    if isinstance(obj, UUID):
+        return str(obj)
+    if isinstance(obj, (bytes, bytearray, memoryview)):
+        return bytes(obj).hex()
+    return str(obj)
+
+
+class _RowsJSONResponse(JSONResponse):
+    """JSONResponse that tolerates DB-native scalar types in row values."""
+
+    def render(self, content: object) -> bytes:
+        return json.dumps(
+            content,
+            ensure_ascii=False,
+            allow_nan=False,
+            separators=(",", ":"),
+            default=_json_default,
+        ).encode("utf-8")
+
 
 # Lazily-created dedicated engine. Prefer ADMIN_QUERY_DATABASE_URL so prod can
 # point this at a dedicated read-only role (`vpt_query`); fall back to the main
@@ -224,6 +266,6 @@ async def admin_sql(request: Request, session: AsyncSession = Depends(get_admin_
             "elapsed_ms": elapsed,
         },
     )
-    return JSONResponse(
+    return _RowsJSONResponse(
         {"rows": out, "rowCount": len(out), "truncated": truncated, "elapsedMs": elapsed}
     )

--- a/apps/api/tests/test_admin_sql.py
+++ b/apps/api/tests/test_admin_sql.py
@@ -11,6 +11,9 @@ These run against the SQLite test session, so the Postgres-specific guards
 `_classify_db_error` unit tests rather than a live Postgres backend.
 """
 
+import uuid
+from datetime import date, datetime, time
+from decimal import Decimal
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
@@ -18,6 +21,34 @@ import pytest
 from fastapi.testclient import TestClient
 
 TOKEN = "a" * 40
+
+
+# ---------------------------------------------------------------------------
+# Result serialization (DB-native types -> JSON)
+# ---------------------------------------------------------------------------
+class TestJsonDefault:
+    def test_coerces_db_native_types(self):
+        from app.routers.admin import _json_default
+
+        assert _json_default(date(2026, 8, 22)) == "2026-08-22"
+        assert _json_default(datetime(2026, 8, 22, 13, 30, 0)) == "2026-08-22T13:30:00"
+        assert _json_default(time(13, 30)) == "13:30:00"
+        # Decimal stays exact (a float round-trip would not)
+        assert _json_default(Decimal("177.45")) == "177.45"
+        u = uuid.uuid4()
+        assert _json_default(u) == str(u)
+        assert _json_default(b"\x01\x02") == "0102"
+        assert _json_default(memoryview(b"\xab")) == "ab"
+
+    def test_unknown_type_falls_back_to_str(self):
+        from app.routers.admin import _json_default
+
+        class Exotic:
+            def __str__(self):
+                return "exotic-value"
+
+        # The str() catch-all guarantees no column type can 500 the endpoint.
+        assert _json_default(Exotic()) == "exotic-value"
 
 
 # ---------------------------------------------------------------------------
@@ -234,6 +265,19 @@ class TestAdminSqlExecution:
         assert body["rowCount"] == 1
         assert body["truncated"] is False
         assert "elapsedMs" in body
+
+    def test_non_json_native_column_does_not_500(self, admin_client):
+        # A BLOB column comes back from SQLite as Python `bytes`, which the
+        # stdlib JSON encoder cannot serialize — the same failure mode as a
+        # Postgres date/numeric/uuid column. Regression: this used to escape
+        # the handler's try/except and surface as an opaque 500.
+        resp = admin_client.post(
+            "/v1/admin/sql",
+            json={"query": "SELECT CAST('hi' AS BLOB) AS b"},
+            headers=_auth(),
+        )
+        assert resp.status_code == 200
+        assert resp.json()["rows"] == [{"b": "6869"}]  # b"hi" -> hex
 
     def test_write_query_rejected(self, admin_client):
         resp = admin_client.post(

--- a/apps/api/tests/test_admin_sql.py
+++ b/apps/api/tests/test_admin_sql.py
@@ -50,6 +50,36 @@ class TestJsonDefault:
         # The str() catch-all guarantees no column type can 500 the endpoint.
         assert _json_default(Exotic()) == "exotic-value"
 
+    def test_render_replaces_non_finite_floats_with_null(self):
+        """A NaN/Infinity float (from a real/double column) isn't routed through
+        `default` and would raise ValueError in render(); it must serialize as
+        null instead of escaping as an opaque 500."""
+        import json
+
+        from app.routers.admin import _RowsJSONResponse
+
+        body = _RowsJSONResponse(
+            {"rows": [{"a": float("nan"), "b": float("inf"), "c": float("-inf"),
+                       "d": 1.5, "s": "ok", "n": 3}]}
+        ).body
+        assert json.loads(body) == {
+            "rows": [{"a": None, "b": None, "c": None, "d": 1.5, "s": "ok", "n": 3}]
+        }
+
+    def test_render_handles_db_native_and_nested(self):
+        """Finite happy path: DB-native scalars and nested containers serialize
+        via _json_default without hitting the non-finite retry."""
+        import json
+
+        from app.routers.admin import _RowsJSONResponse
+
+        body = _RowsJSONResponse(
+            {"rows": [{"d": date(2026, 8, 22), "amounts": [Decimal("1.10"), Decimal("2.20")]}]}
+        ).body
+        assert json.loads(body) == {
+            "rows": [{"d": "2026-08-22", "amounts": ["1.10", "2.20"]}]
+        }
+
 
 # ---------------------------------------------------------------------------
 # Query validator (pure logic)


### PR DESCRIPTION
## Summary

- `POST /v1/admin/sql` returned an opaque **500** whenever a result column was a raw `date`, `timestamp`, `numeric`/`Decimal`, `uuid`, or `bytea` — forcing callers to `::text`-cast every such column (hit repeatedly while debugging the SFO→RDM trip: `SELECT depart_date` / `SELECT flight_price` both 500'd).
- **Root cause:** the success path returns raw query rows via the default `JSONResponse`, whose stdlib `json.dumps` can't encode those Python types. The render happens *outside* the handler's `try/except`, so the `TypeError` escaped as a bare 500 (no structured `details`) instead of the endpoint's own error JSON — which is why DB-level errors showed `server_error` details but a `date` column showed a contentless 500.
- **Fix:** render the success payload through `_json_default`, coercing dates → `isoformat()`, `Decimal` → `str` (preserves exact price precision — a float round-trip would not), `UUID` → `str`, `bytes` → hex, with a `str()` catch-all so **no column type can 500 this debug endpoint again**. Error responses are unchanged.

## Test plan

- [x] `_json_default` unit tests (date/datetime/time/Decimal/UUID/bytes/memoryview + unknown-type `str()` fallback)
- [x] End-to-end test: a SQLite `BLOB` column (returns Python `bytes`, the same failure mode as a Postgres date/numeric) now returns `200` instead of `500`
- [x] `apps/api/app/routers/admin.py` at 100% coverage; api gate green (96.22%); lint clean
- [x] `pnpm verify` green
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CLU2qzji7MCM2UREz8yaZR

---
_Generated by [Claude Code](https://claude.ai/code/session_015cwzPiyQfJKxYUhR6oCbfa)_