### PR TITLE
chore: make prod DB/Axiom debugging work from web sessions

### DIFF
--- a/.claude/skills/debugging-prod/SKILL.md
+++ b/.claude/skills/debugging-prod/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: debugging-prod
-description: Investigate production issues for the self-hosted Vacation Price Tracker stack (project vpt-prod). Use when something is broken or suspicious in prod — 5xx/empty responses, a tracked trip with wrong/stale prices, a stuck or failing price-check workflow, missing notifications, slow/odd LLM chat behaviour, or a deploy that won't come healthy. Covers the read paths: docker logs on the prod host, structured app logs in Axiom (when configured), the /v1/admin/sql endpoint (via `pnpm prod:query`), the Temporal Web UI, Langfuse, and the /ready probe.
+description: Investigate production issues for the self-hosted Vacation Price Tracker stack (project vpt-prod). Use when something is broken or suspicious in prod — 5xx/empty responses, a tracked trip with wrong/stale prices, a stuck or failing price-check workflow, missing notifications, slow/odd LLM chat behaviour, or a deploy that won't come healthy. Covers the read paths: docker logs on the prod host, structured app logs in Axiom (via `pnpm prod:axiom`), the /v1/admin/sql endpoint (via `pnpm prod:query`), the Temporal Web UI, Langfuse, and the /ready probe. From a Claude Code web session, `pnpm prod:query` and `pnpm prod:axiom` work out of the box using injected shell-env credentials (no .env.prod).
 ---
 
 # Debugging production (vpt-prod)
@@ -19,16 +19,60 @@ from GHCR. This skill is the **read/diagnose** counterpart to the local
 App logging is stdlib `logging` → stdout → Docker's `json-file` driver, **and**
 shipped to **Axiom** when `AXIOM_TOKEN`/`AXIOM_DATASET` are set in `.env.prod`
 (one dataset, `vacation-price-tracker-prod`, for api + worker + web — distinguished by `service` /
-`component`). LLM/MCP calls are traced in **Langfuse**. Query Axiom with a PAT
-(Query capability) + `X-AXIOM-ORG-ID` header — the repo's ingest token can't read.
-Logs are structured: filter on `event` (dotted namespace), `level`, `service`,
-`trip_id`, `workflow_id`; non-core fields are under the `fields` map
-(`['fields']['key']`). See `docs/specs/operations/axiom-map-fields.md`. Example:
+`component`). LLM/MCP calls are traced in **Langfuse**.
+
+### Credentials & access (read this first in a web session)
+
+A Claude Code **web/remote session is NOT the prod host** — there is no
+`.env.prod`, and the dev `.env` is useless for prod (`BACKEND_URL` there points
+at `localhost`). Instead the prod read-credentials are injected into the **shell
+environment**:
+
+| Env var | What it is | Used by |
+|---------|-----------|---------|
+| `ADMIN_QUERY_URL` | prod API origin (`https://vacation-price-tracker.ethanasm.me`) | `pnpm prod:query` (auto-resolved) |
+| `ADMIN_QUERY_TOKEN` | bearer token for `/v1/admin/sql` | `pnpm prod:query` |
+| `AXIOM_QUERY_TOKEN` | PAT with Query capability (the ingest token can't read) | `pnpm prod:axiom` |
+| `AXIOM_ORG_ID` | Axiom org slug (`showbook-egap`) | `pnpm prod:axiom` |
+
+So the two read paths **just work** from a web session: `pnpm prod:query "…"`
+for Postgres and `pnpm prod:axiom "…"` for logs. The Docker / Temporal / Langfuse
+paths below require being on (or tunnelled to) the prod host and are not
+reachable from a plain web session. Check `env | grep -E 'ADMIN_QUERY|AXIOM'` if
+unsure what's available.
+
+### Querying Axiom — `pnpm prod:axiom`
+
+Prefer the helper; it wraps the PAT auth, JSON escaping, and the column-oriented
+"tabular" response (fiddly to read by hand). **Don't reach for the Axiom MCP
+tools first** — that server's own token is usually expired in web sessions; the
+PAT helper is the reliable path. Raw `curl` (below) is the fallback.
 
 ```bash
-ORG=${AXIOM_ORG_ID:-showbook-egap}   # Axiom org slug hosting the vacation-price-tracker-prod dataset
+pnpm prod:axiom "['vacation-price-tracker-prod'] | where _time > ago(24h) | summarize count() by service, level"
+pnpm prod:axiom --json "['vacation-price-tracker-prod'] | where level == 'error' | take 20"
+```
+
+APL gotchas (each one cost a wasted query the first time):
+- **Always constrain time** — `| where _time > ago(24h)`. The `_apl` endpoint
+  otherwise scans a ~1-year default window.
+- The message column is **`msg`**, not `message`.
+- App-supplied fields (`logger`, `trip_id`, `workflow_id`, `count`, …) fold into
+  the **`fields` map** — query as `['fields']['logger']`, *not* as top-level
+  columns. Only `CORE_FIELDS` (`_time`, `service`, `level`, `event`, `env`,
+  `hostname`, `pid`, `msg`, `status`) and the `err.*` allowlist are real columns.
+  `getschema` / `getDatasetFields` won't list keys inside the map — sample a row.
+- Third-party library logs (langfuse, temporalio, uvicorn) arrive with
+  **`event == null`** — that's expected, not a wiring bug. App events carry a
+  dotted `event` (e.g. `trips.users.ok`, `admin.sql.executed`).
+- Low/zero volume usually means idle prod, not broken shipping — cross-check with
+  `pnpm prod:query "SELECT count(*) FROM trips"` before assuming Axiom is down.
+
+Raw fallback (if the helper is unavailable):
+
+```bash
 curl -sS -X POST "https://api.axiom.co/v1/datasets/_apl?format=tabular" \
-  -H "Authorization: Bearer $AXIOM_QUERY_TOKEN" -H "X-AXIOM-ORG-ID: $ORG" \
+  -H "Authorization: Bearer $AXIOM_QUERY_TOKEN" -H "X-AXIOM-ORG-ID: ${AXIOM_ORG_ID:-showbook-egap}" \
   -H "Content-Type: application/json" \
   -d '{"apl":"[\"vacation-price-tracker-prod\"] | where _time > ago(1h) and level in (\"warn\",\"error\") | sort by _time desc"}'
 ```
@@ -65,7 +109,9 @@ pnpm prod:query --json "SELECT id, status FROM trips WHERE status='Error'"
 echo "SELECT now()" | pnpm prod:query
 ```
 
-Reads `ADMIN_QUERY_TOKEN` + `PROD_API_URL`/`BACKEND_URL` from `.env.prod`.
+Reads `ADMIN_QUERY_TOKEN` + the API base URL. On the prod host that's
+`PROD_API_URL`/`BACKEND_URL` from `.env.prod`; in a web session it falls back to
+`ADMIN_QUERY_URL` from the shell env automatically (no `.env.prod` needed).
 Read-only is enforced server-side (Postgres `READ ONLY` txn, always rolled back),
 plus a 3 s statement timeout, 1000-row cap, and per-IP rate limit. Only
 `SELECT`/`WITH`/`EXPLAIN`/`SHOW`/`TABLE`/`VALUES` are accepted. See the recipe

--- a/package.json
+++ b/package.json
@@ -51,7 +51,8 @@
     "prod:db:migrate": "docker compose --env-file .env.prod -f infra/docker-compose.prod.yml run --rm --entrypoint sh api -c 'cd /app && alembic upgrade head'",
     "prod:db:backup": "mkdir -p backups && docker compose --env-file .env.prod -f infra/docker-compose.prod.yml exec -T db pg_dump --format=custom --no-owner --no-acl -U postgres vacation_tracker > \"backups/pre-migrate-${DEPLOY_SHA:-$(date -u +%Y%m%dT%H%M%SZ)}.dump\"",
     "prod:health:ready": "curl -fsS --retry 12 --retry-delay 5 --retry-all-errors http://127.0.0.1:8001/ready",
-    "prod:query": "node scripts/prod-query.mjs"
+    "prod:query": "node scripts/prod-query.mjs",
+    "prod:axiom": "node scripts/prod-axiom.mjs"
   },
   "devDependencies": {
     "@nx/next": "23.0.0",

--- a/scripts/prod-axiom.mjs
+++ b/scripts/prod-axiom.mjs
@@ -1,0 +1,141 @@
+#!/usr/bin/env node
+// Run an APL query against the production Axiom dataset and pretty-print the
+// result. This is the read counterpart to prod-query.mjs (which hits Postgres):
+// app logs from api + worker are shipped to one Axiom dataset and this is the
+// supported way for the operator (and Claude Code) to read them.
+//
+// Prefer this over the raw `curl .../_apl` recipe — it handles the auth headers,
+// JSON escaping, and the column-oriented "tabular" response shape (which is
+// fiddly to read by hand). The Axiom MCP server's own token is frequently
+// expired in web sessions, so this PAT-based path is the reliable one.
+//
+// Usage:
+//   pnpm prod:axiom "['vacation-price-tracker-prod'] | where _time > ago(1h) | summarize count() by service"
+//   pnpm prod:axiom --json "['vacation-price-tracker-prod'] | where level == 'error' | take 20"
+//   echo "['vacation-price-tracker-prod'] | summarize count()" | pnpm prod:axiom
+//
+// Config (from the environment; .env.prod is NOT consulted — these come from the
+// shell env in web sessions, never the dev .env file):
+//   AXIOM_QUERY_TOKEN  required, a PAT with Query capability (the ingest token
+//                      used by the app cannot read)
+//   AXIOM_ORG_ID       Axiom org slug; defaults to showbook-egap
+//   AXIOM_DATASET      default dataset name; defaults to vacation-price-tracker-prod
+//
+// APL gotchas you will hit (these are why the helper exists):
+//   - Always constrain time: `| where _time > ago(24h)`. The _apl endpoint
+//     otherwise scans a ~1 year default window.
+//   - The log message column is `msg`, NOT `message`.
+//   - App-supplied fields (logger, trip_id, workflow_id, count, …) are folded
+//     into the `fields` map — query them as `['fields']['logger']`, not as
+//     top-level columns. Only CORE_FIELDS (_time, service, level, event, env,
+//     hostname, pid, msg, status) and the err.* allowlist are real columns.
+//   - Third-party library logs (langfuse, temporalio, uvicorn) arrive with
+//     `event == null`; that's expected, not a misconfiguration.
+
+import { fileURLToPath } from "node:url";
+import { dirname } from "node:path";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+function die(msg) {
+  console.error(`prod-axiom: ${msg}`);
+  process.exit(1);
+}
+
+async function readStdin() {
+  const chunks = [];
+  for await (const chunk of process.stdin) chunks.push(chunk);
+  return Buffer.concat(chunks).toString("utf8").trim();
+}
+
+// The /_apl?format=tabular response is column-oriented:
+//   tables[0].fields  = [{name}, …]
+//   tables[0].columns = [[col0 values…], [col1 values…], …]
+// Transpose into an array of row objects for console.table.
+function tabularToRows(payload) {
+  const table = payload?.tables?.[0];
+  if (!table || !Array.isArray(table.fields) || !Array.isArray(table.columns)) {
+    return [];
+  }
+  const names = table.fields.map((f) => f.name);
+  const colCount = table.columns.length;
+  const rowCount = colCount ? table.columns[0].length : 0;
+  const rows = [];
+  for (let r = 0; r < rowCount; r++) {
+    const row = {};
+    for (let c = 0; c < colCount; c++) {
+      let v = table.columns[c][r];
+      if (v !== null && typeof v === "object") v = JSON.stringify(v);
+      row[names[c]] = v;
+    }
+    rows.push(row);
+  }
+  return rows;
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  let asJson = false;
+  const aplParts = [];
+  for (const arg of args) {
+    if (arg === "--json") asJson = true;
+    else aplParts.push(arg);
+  }
+
+  let apl = aplParts.join(" ").trim();
+  if (!apl && !process.stdin.isTTY) apl = await readStdin();
+  if (!apl) {
+    die('no APL provided. Usage: pnpm prod:axiom "[\'vacation-price-tracker-prod\'] | summarize count()"');
+  }
+
+  const token = process.env.AXIOM_QUERY_TOKEN;
+  if (!token) die("AXIOM_QUERY_TOKEN is not set (needs a PAT with Query capability)");
+  const org = process.env.AXIOM_ORG_ID || "showbook-egap";
+
+  const url = "https://api.axiom.co/v1/datasets/_apl?format=tabular";
+  let res;
+  try {
+    res = await fetch(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+        "X-AXIOM-ORG-ID": org,
+      },
+      body: JSON.stringify({ apl }),
+    });
+  } catch (err) {
+    die(`request to Axiom failed: ${err.message}`);
+  }
+
+  const raw = await res.text();
+  let payload;
+  try {
+    payload = JSON.parse(raw);
+  } catch {
+    die(`HTTP ${res.status}: non-JSON response: ${raw.slice(0, 500)}`);
+  }
+
+  if (!res.ok) {
+    die(`HTTP ${res.status}: ${payload.message || payload.error || raw.slice(0, 300)}`);
+  }
+
+  // Surface query-planner warnings (e.g. license-limited time range) to stderr.
+  for (const m of payload?.status?.messages || []) {
+    console.error(`axiom[${m.priority || "note"}]: ${m.msg}`);
+  }
+
+  if (asJson) {
+    console.log(JSON.stringify(payload, null, 2));
+    return;
+  }
+
+  const rows = tabularToRows(payload);
+  if (rows.length === 0) console.log("(0 rows)");
+  else console.table(rows);
+  const examined = payload?.status?.rowsExamined;
+  const elapsed = payload?.status?.elapsedTime;
+  console.error(`${rows.length} row(s)${examined != null ? `, ${examined} examined` : ""}${elapsed != null ? ` in ${elapsed}ms` : ""}`);
+}
+
+main().catch((err) => die(err?.message || String(err)));

--- a/scripts/prod-axiom.mjs
+++ b/scripts/prod-axiom.mjs
@@ -14,12 +14,12 @@
 //   pnpm prod:axiom --json "['vacation-price-tracker-prod'] | where level == 'error' | take 20"
 //   echo "['vacation-price-tracker-prod'] | summarize count()" | pnpm prod:axiom
 //
-// Config (from the environment; .env.prod is NOT consulted — these come from the
-// shell env in web sessions, never the dev .env file):
+// Config (from .env.prod at repo root, or the environment — env wins; in web
+// sessions these come from the shell env, never the dev .env file):
 //   AXIOM_QUERY_TOKEN  required, a PAT with Query capability (the ingest token
 //                      used by the app cannot read)
 //   AXIOM_ORG_ID       Axiom org slug; defaults to showbook-egap
-//   AXIOM_DATASET      default dataset name; defaults to vacation-price-tracker-prod
+// The dataset name is written inline in the APL (e.g. ['vacation-price-tracker-prod']).
 //
 // APL gotchas you will hit (these are why the helper exists):
 //   - Always constrain time: `| where _time > ago(24h)`. The _apl endpoint
@@ -32,10 +32,40 @@
 //   - Third-party library logs (langfuse, temporalio, uvicorn) arrive with
 //     `event == null`; that's expected, not a misconfiguration.
 
+import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
-import { dirname } from "node:path";
+import { dirname, resolve } from "node:path";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
+const ENV_PATH = resolve(__dirname, "..", ".env.prod");
+
+// Mirror prod-query.mjs: read .env.prod on the prod host, fall back to the shell
+// environment (which is how web sessions get these vars). Env wins over file.
+function loadEnvFile(path) {
+  const out = {};
+  let text;
+  try {
+    text = readFileSync(path, "utf8");
+  } catch {
+    return out; // missing .env.prod is fine if vars are in the environment
+  }
+  for (const line of text.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) continue;
+    const eq = trimmed.indexOf("=");
+    if (eq === -1) continue;
+    const key = trimmed.slice(0, eq).trim();
+    let val = trimmed.slice(eq + 1).trim();
+    if (
+      (val.startsWith('"') && val.endsWith('"')) ||
+      (val.startsWith("'") && val.endsWith("'"))
+    ) {
+      val = val.slice(1, -1);
+    }
+    out[key] = val;
+  }
+  return out;
+}
 
 function die(msg) {
   console.error(`prod-axiom: ${msg}`);
@@ -88,9 +118,12 @@ async function main() {
     die('no APL provided. Usage: pnpm prod:axiom "[\'vacation-price-tracker-prod\'] | summarize count()"');
   }
 
-  const token = process.env.AXIOM_QUERY_TOKEN;
-  if (!token) die("AXIOM_QUERY_TOKEN is not set (needs a PAT with Query capability)");
-  const org = process.env.AXIOM_ORG_ID || "showbook-egap";
+  const fileEnv = loadEnvFile(ENV_PATH);
+  const getVar = (name) => process.env[name] ?? fileEnv[name];
+
+  const token = getVar("AXIOM_QUERY_TOKEN");
+  if (!token) die("AXIOM_QUERY_TOKEN is not set (.env.prod or environment; needs a PAT with Query capability)");
+  const org = getVar("AXIOM_ORG_ID") || "showbook-egap";
 
   const url = "https://api.axiom.co/v1/datasets/_apl?format=tabular";
   let res;
@@ -117,7 +150,7 @@ async function main() {
   }
 
   if (!res.ok) {
-    die(`HTTP ${res.status}: ${payload.message || payload.error || raw.slice(0, 300)}`);
+    die(`HTTP ${res.status}: ${payload?.message || payload?.error || raw.slice(0, 300)}`);
   }
 
   // Surface query-planner warnings (e.g. license-limited time range) to stderr.

--- a/scripts/prod-query.mjs
+++ b/scripts/prod-query.mjs
@@ -115,8 +115,8 @@ async function main() {
   }
 
   if (!res.ok) {
-    const detail = payload.details ? ` — ${payload.details}` : "";
-    die(`HTTP ${res.status} ${payload.error || "error"}${detail}`);
+    const detail = payload?.details ? ` — ${payload.details}` : "";
+    die(`HTTP ${res.status} ${payload?.error || "error"}${detail}`);
   }
 
   if (asJson) {

--- a/scripts/prod-query.mjs
+++ b/scripts/prod-query.mjs
@@ -11,8 +11,11 @@
 //
 // Config (from .env.prod at repo root, or the environment — env wins):
 //   ADMIN_QUERY_TOKEN  required, the Bearer token (>= 32 chars)
-//   PROD_API_URL       API base URL; falls back to BACKEND_URL; default
-//                      http://127.0.0.1:8001 (the loopback bind in prod compose)
+//   PROD_API_URL       API base URL; falls back to BACKEND_URL, then
+//                      ADMIN_QUERY_URL (the var Claude Code web sessions inject),
+//                      then http://127.0.0.1:8001 (the loopback bind in prod
+//                      compose). ADMIN_QUERY_URL may be the API origin or the
+//                      full /v1/admin/sql endpoint — both are accepted.
 //
 // Only read-only statements are accepted; the endpoint enforces that server-side.
 
@@ -82,7 +85,11 @@ async function main() {
   if (!token) die("ADMIN_QUERY_TOKEN is not set (.env.prod or environment)");
   if (token.length < 32) die("ADMIN_QUERY_TOKEN must be >= 32 chars");
 
-  const base = (getVar("PROD_API_URL") || getVar("BACKEND_URL") || "http://127.0.0.1:8001").replace(/\/$/, "");
+  // ADMIN_QUERY_URL is injected into Claude Code web sessions; it may be the API
+  // origin or the full endpoint, so normalise either to a base before appending.
+  const base = (getVar("PROD_API_URL") || getVar("BACKEND_URL") || getVar("ADMIN_QUERY_URL") || "http://127.0.0.1:8001")
+    .replace(/\/$/, "")
+    .replace(/\/v1\/admin\/sql$/, "");
   const url = `${base}/v1/admin/sql`;
 
   let res;


### PR DESCRIPTION
## Summary

- **`prod-query.mjs`**: resolve `ADMIN_QUERY_URL` (the API origin injected into Claude Code web sessions) as a base-URL fallback, normalizing origin-vs-full-endpoint. `pnpm prod:query` now works from a web session without a `.env.prod` or a manual `PROD_API_URL=…` override.
- **New `scripts/prod-axiom.mjs` + `pnpm prod:axiom`**: query the prod Axiom dataset the same way `prod:query` hits Postgres — wraps PAT auth (`AXIOM_QUERY_TOKEN` + `X-AXIOM-ORG-ID`), JSON escaping, and the column-oriented "tabular" response into a `console.table`. Replaces hand-rolled `curl` + manual response parsing.
- **`debugging-prod` skill**: document the web-session shell-env credentials (`ADMIN_QUERY_URL`, `ADMIN_QUERY_TOKEN`, `AXIOM_QUERY_TOKEN`, `AXIOM_ORG_ID`), note that the Axiom MCP server token is usually expired in web sessions (prefer the PAT helper), and capture the APL gotchas that cost wasted queries (constrain `_time`, `msg` not `message`, app fields under the `fields` map, third-party logs have `event == null`).

### Why
Debugging prod from a Claude Code web session snagged on the skill assuming the prod host (`.env.prod`, localhost binds). The credentials are actually injected into the shell env under different names, so `pnpm prod:query` defaulted to localhost and the Axiom path required hand-rolled curl. These changes make both read paths work out of the box.

## Test plan

- [x] `pnpm verify` green (build, lint, typecheck, test:coverage, security audits — Python coverage 96.67%)
- [x] `pnpm prod:query "SELECT count(*) FROM users"` returns a row from prod with no `PROD_API_URL` override
- [x] `pnpm prod:axiom "['vacation-price-tracker-prod'] | where _time > ago(24h) | summarize count() by service, level"` renders a table
- [x] `package.json` parses; `prod:axiom` script wired
- [ ] N/A — no app/UI code touched (tooling + skill docs only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CLU2qzji7MCM2UREz8yaZR

---
_Generated by [Claude Code](https://claude.ai/code/session_01NDrkTxTdPgUTpKUSnShwhZ)_