### PR TITLE
docs: drop conflicting rebase example from creating-prs skill

### DIFF
--- a/.claude/skills/creating-prs/SKILL.md
+++ b/.claude/skills/creating-prs/SKILL.md
@@ -91,8 +91,8 @@ describe the *current* head of the branch, not just the first commit. A
 follow-up commit that adds, removes, or materially changes behavior, files, or
 test coverage without a matching body edit leaves the description stale — treat
 that as a bug in your own workflow, not an optional nicety. Pure-mechanical
-pushes that don't change the description's claims (a lint-only fix, a rebase with
-no behavior delta) don't need an edit, but when in doubt, update it.
+pushes that don't change the description's claims (a lint-only fix, a
+comment/typo fix) don't need an edit, but when in doubt, update it.
 
 ### 4. Attach visual review material if the diff touches UI
 


### PR DESCRIPTION
## Summary

- Follow-up to #30. The peer review flagged a P2 self-conflict: the new "Keep the body in sync with the diff" block listed "a rebase with no behavior delta" as an example of a routine mechanical push, but the same skill (SKILL.md:52) explicitly forbids rebasing onto main. Replaced it with a comment/typo-fix example so the guidance is internally consistent.

## Test plan

- [x] Docs/skill-markdown-only change — no app code touched.
- [x] `git diff --name-only origin/main...HEAD` confirms only `.claude/skills/creating-prs/SKILL.md` changes; no UI paths, so no screenshots needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CLU2qzji7MCM2UREz8yaZR

---
_Generated by [Claude Code](https://claude.ai/code/session_01CLEy3NLaLDfz1jAJmx6fVQ)_