### PR TITLE
feat(web): Aurora redesign across all five routes

### DIFF
--- a/apps/web/src/__tests__/aurora-tokens.test.ts
+++ b/apps/web/src/__tests__/aurora-tokens.test.ts
@@ -1,0 +1,54 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const css = readFileSync(
+  join(__dirname, "..", "app", "globals.css"),
+  "utf8",
+);
+
+describe("Aurora design tokens in globals.css", () => {
+  it.each([
+    ["--aurora-violet", "#7C3AED"],
+    ["--aurora-violet-deep", "#6D28D9"],
+    ["--aurora-pink", "#EC4899"],
+    ["--aurora-cyan", "#22D3EE"],
+    ["--aurora-page", "#FAF8FF"],
+    ["--aurora-surface", "#F4F1FC"],
+    ["--aurora-surface-2", "#F8F5FE"],
+    ["--aurora-chip", "#EDE9FE"],
+    ["--aurora-hairline", "#F1EEF8"],
+    ["--aurora-selected-border", "#C9B8F5"],
+    ["--aurora-ink", "#1A1A2E"],
+    ["--aurora-success", "#059669"],
+    ["--aurora-warn", "#9A7B18"],
+    ["--aurora-layover", "#C98A3A"],
+    ["--aurora-star", "#F5A623"],
+  ])("defines %s = %s", (name, hex) => {
+    const re = new RegExp(`${name}:\\s*${hex}`, "i");
+    expect(css).toMatch(re);
+  });
+
+  it("defines the primary and total gradients", () => {
+    expect(css).toMatch(/--aurora-grad-primary:\s*linear-gradient\(135deg,\s*#A78BFA,\s*#7C3AED\)/i);
+    expect(css).toMatch(/--aurora-grad-total:\s*linear-gradient\(135deg,\s*#7C3AED,\s*#9333EA\)/i);
+  });
+
+  it("defines the card-on-canvas shadow", () => {
+    expect(css).toMatch(/--aurora-shadow-card:\s*0 16px 50px rgba\(60,\s*40,\s*120,\s*\.13\)/i);
+  });
+
+  it.each([
+    ".aurora-logo",
+    ".aurora-avatar",
+    ".aurora-total-card",
+    ".aurora-chip-active",
+    ".aurora-chip-paused",
+    ".aurora-chip-nonstop",
+    ".aurora-chip-stop",
+    ".aurora-card",
+    ".aurora-hairline",
+    ".aurora-layover-pill",
+  ])("defines utility class %s", (cls) => {
+    expect(css).toContain(cls);
+  });
+});

--- a/apps/web/src/__tests__/aurora.test.ts
+++ b/apps/web/src/__tests__/aurora.test.ts
@@ -1,0 +1,70 @@
+import {
+  airlineChip,
+  operatingCarriers,
+  multiCarrierSubtitle,
+  stopsBadge,
+  layoverLabel,
+} from "@/lib/aurora";
+import type { ApiFlightOffer, ApiFlightSegment } from "@/lib/api";
+
+const seg = (over: Partial<ApiFlightSegment>): ApiFlightSegment => ({
+  carrier_code: "UA", flight_number: "UA508",
+  departure_airport: "SFO", arrival_airport: "DEN",
+  departure_time: "2025-08-22T07:05:00", arrival_time: "2025-08-22T10:30:00",
+  duration_minutes: 205, ...over,
+});
+
+const nonstop: ApiFlightOffer = {
+  id: "as1", airline_code: "AS", price: "177", stops: 0,
+  itineraries: [{ direction: "outbound", stops: 0, segments: [seg({ carrier_code: "AS", flight_number: "AS1", arrival_airport: "RDM" })] }],
+};
+const oneStopMulti: ApiFlightOffer = {
+  id: "ua1", airline_code: "UA", price: "154", stops: 1,
+  itineraries: [{ direction: "outbound", stops: 1, segments: [
+    seg({ carrier_code: "UA", flight_number: "UA508", arrival_airport: "DEN", arrival_time: "2025-08-22T10:30:00" }),
+    seg({ carrier_code: "AS", flight_number: "AS2201", departure_airport: "DEN", arrival_airport: "RDM", departure_time: "2025-08-22T11:40:00" }),
+  ] }],
+};
+
+describe("airlineChip", () => {
+  it("maps AS/UA/DL to their gradients", () => {
+    expect(airlineChip("AS")).toEqual({ initials: "AS", gradient: "linear-gradient(135deg,#10617F,#093247)" });
+    expect(airlineChip("UA")).toEqual({ initials: "UA", gradient: "linear-gradient(135deg,#2456C9,#13357F)" });
+    expect(airlineChip("DL")).toEqual({ initials: "DL", gradient: "linear-gradient(135deg,#C8102E,#7A0A1C)" });
+  });
+  it("falls back to two-letter initials + violet gradient", () => {
+    expect(airlineChip("b6")).toEqual({ initials: "B6", gradient: "linear-gradient(135deg,#A78BFA,#7C3AED)" });
+    expect(airlineChip(null).initials).toBe("--");
+  });
+});
+
+describe("operatingCarriers + multiCarrierSubtitle", () => {
+  it("single carrier → no subtitle", () => {
+    expect(operatingCarriers(nonstop)).toEqual(["Alaska"]);
+    expect(multiCarrierSubtitle(nonstop)).toBeNull();
+  });
+  it("two carriers → 'Operated by United & Alaska'", () => {
+    expect(operatingCarriers(oneStopMulti)).toEqual(["United", "Alaska"]);
+    expect(multiCarrierSubtitle(oneStopMulti)).toBe("Operated by United & Alaska");
+  });
+});
+
+describe("stopsBadge", () => {
+  it("non-stop → success NON-STOP", () => {
+    expect(stopsBadge(nonstop)).toEqual({ label: "NON-STOP", tone: "success" });
+  });
+  it("one stop → warning with via airport", () => {
+    expect(stopsBadge(oneStopMulti)).toEqual({ label: "1 STOP · DEN", tone: "warning" });
+  });
+});
+
+describe("layoverLabel", () => {
+  it("formats the layover with city + code", () => {
+    const segments = oneStopMulti.itineraries?.[0]?.segments ?? [];
+    const [a, b] = segments;
+    expect(layoverLabel(a, b)).toBe("1h 10m layover in Denver (DEN)");
+  });
+  it("returns null when times are missing", () => {
+    expect(layoverLabel({ ...seg({}), arrival_time: null }, seg({}))).toBeNull();
+  });
+});

--- a/apps/web/src/__tests__/badge-aurora.test.tsx
+++ b/apps/web/src/__tests__/badge-aurora.test.tsx
@@ -1,0 +1,21 @@
+import { render } from "@testing-library/react";
+import { Badge } from "@/components/ui/badge";
+
+describe("Badge Aurora variants", () => {
+  it("active variant uses the violet chip class", () => {
+    const { getByText } = render(<Badge variant="active">ACTIVE</Badge>);
+    expect(getByText("ACTIVE")).toHaveClass("aurora-chip-active");
+  });
+  it("paused variant uses the amber chip class", () => {
+    const { getByText } = render(<Badge variant="paused">PAUSED</Badge>);
+    expect(getByText("PAUSED")).toHaveClass("aurora-chip-paused");
+  });
+  it("nonstop variant uses the green chip class", () => {
+    const { getByText } = render(<Badge variant="nonstop">NON-STOP</Badge>);
+    expect(getByText("NON-STOP")).toHaveClass("aurora-chip-nonstop");
+  });
+  it("stop variant uses the amber stop chip class", () => {
+    const { getByText } = render(<Badge variant="stop">1 STOP</Badge>);
+    expect(getByText("1 STOP")).toHaveClass("aurora-chip-stop");
+  });
+});

--- a/apps/web/src/__tests__/components/chat/chat-panel.test.tsx
+++ b/apps/web/src/__tests__/components/chat/chat-panel.test.tsx
@@ -77,7 +77,7 @@ describe("ChatPanel", () => {
     it("renders header with title", () => {
       renderWithProvider(<ChatPanel />);
 
-      expect(screen.getByText("Travel Assistant")).toBeInTheDocument();
+      expect(screen.getByText("Assistant")).toBeInTheDocument();
     });
 
     it("renders chat input", () => {

--- a/apps/web/src/__tests__/dashboard-aurora.test.tsx
+++ b/apps/web/src/__tests__/dashboard-aurora.test.tsx
@@ -123,4 +123,52 @@ describe("Dashboard (Aurora)", () => {
     expect(screen.getByText(/Showing 2 of 2 trips/i)).toBeInTheDocument();
     expect(screen.getByText(/refresh daily at 6:00 AM/i)).toBeInTheDocument();
   });
+
+  describe("compact viewport (≤820px)", () => {
+    beforeEach(() => {
+      // The dashboard swaps the table for stacked trip cards below 820px,
+      // driven by useMediaQuery -> window.matchMedia. jsdom has no matchMedia,
+      // so emulate a matching (mobile) query for this branch.
+      Object.defineProperty(window, "matchMedia", {
+        writable: true,
+        configurable: true,
+        value: (query: string) => ({
+          matches: true,
+          media: query,
+          onchange: null,
+          addEventListener: jest.fn(),
+          removeEventListener: jest.fn(),
+          addListener: jest.fn(),
+          removeListener: jest.fn(),
+          dispatchEvent: jest.fn(),
+        }),
+      });
+    });
+
+    afterEach(() => {
+      // Restore desktop default so the table-path test is unaffected by order.
+      Object.defineProperty(window, "matchMedia", {
+        writable: true,
+        configurable: true,
+        value: undefined,
+      });
+    });
+
+    it("renders stacked trip cards with status chips and Flight/Hotel/Total mini-stats", async () => {
+      render(<DashboardPage />);
+      await waitFor(() =>
+        expect(screen.getByText("Test 2")).toBeInTheDocument(),
+      );
+
+      // Stacked cards, not the table: the Aurora status chips still render…
+      expect(screen.getByText("ACTIVE")).toHaveClass("aurora-chip-active");
+      expect(screen.getByText("PAUSED")).toHaveClass("aurora-chip-paused");
+      // …each card shows the three mini-stats…
+      expect(screen.getAllByText("Flight").length).toBeGreaterThan(0);
+      expect(screen.getAllByText("Hotel").length).toBeGreaterThan(0);
+      expect(screen.getAllByText("Total").length).toBeGreaterThan(0);
+      // …and the violet/bold per-trip total.
+      expect(screen.getByText("$789")).toBeInTheDocument();
+    });
+  });
 });

--- a/apps/web/src/__tests__/dashboard-aurora.test.tsx
+++ b/apps/web/src/__tests__/dashboard-aurora.test.tsx
@@ -1,0 +1,126 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import DashboardPage from "@/app/trips/page";
+
+// next/navigation router (used by trip-row-actions and elsewhere)
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: jest.fn() }),
+}));
+
+// sonner toasts (avoid side effects)
+jest.mock("sonner", () => ({
+  toast: {
+    success: jest.fn(),
+    error: jest.fn(),
+    warning: jest.fn(),
+    info: jest.fn(),
+  },
+}));
+
+// SSE hook — real module path is @/hooks/use-sse exporting useSSE returning { isConnected }
+jest.mock("@/hooks/use-sse", () => ({
+  useSSE: () => ({
+    connectionState: "connected",
+    isConnected: true,
+    priceUpdates: [],
+    error: null,
+    connect: jest.fn(),
+    disconnect: jest.fn(),
+    clearUpdates: jest.fn(),
+  }),
+}));
+
+// Chat provider / panel — avoid network calls
+jest.mock("@/lib/chat-provider", () => ({
+  ChatProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  useChatContext: () => ({
+    threadId: "mock-thread-id",
+    pendingElicitation: null,
+    setPendingElicitation: jest.fn(),
+    processElicitationResponse: jest.fn(),
+    messages: [],
+    isLoading: false,
+    error: null,
+    pendingRefreshIds: new Set(),
+    sendMessage: jest.fn(),
+    clearMessages: jest.fn(),
+    retryLastMessage: jest.fn(),
+    switchThread: jest.fn(),
+    startNewThread: jest.fn(),
+  }),
+}));
+
+jest.mock("@/components/chat/chat-panel", () => ({
+  ChatPanel: () => <div data-testid="chat-panel">Assistant</div>,
+}));
+
+jest.mock("@/components/chat/elicitation-drawer", () => ({
+  ElicitationDrawer: () => null,
+}));
+
+jest.mock("@/components/dashboard/chat-toggle", () => ({
+  useChatExpanded: (defaultValue: boolean) => ({
+    isExpanded: defaultValue,
+    setExpanded: jest.fn(),
+    isHydrated: true,
+  }),
+  ChatToggle: () => null,
+  FloatingChatToggle: () => null,
+}));
+
+jest.mock("@/lib/api", () => ({
+  ApiError: class ApiError extends Error {
+    status = 0;
+    detail = "";
+  },
+  api: {
+    trips: {
+      list: jest.fn().mockResolvedValue({
+        data: [
+          {
+            id: "1",
+            name: "Test 2",
+            origin_airport: "SFO",
+            destination_code: "RDM",
+            depart_date: "2025-08-22",
+            return_date: "2025-08-26",
+            status: "active",
+            current_flight_price: "177",
+            current_hotel_price: "612",
+            total_price: "789",
+            last_refreshed: "2025-08-01T00:00:00Z",
+          },
+          {
+            id: "2",
+            name: "Tokyo",
+            origin_airport: "LAX",
+            destination_code: "HND",
+            depart_date: "2026-03-20",
+            return_date: "2026-03-28",
+            status: "paused",
+            current_flight_price: "842",
+            current_hotel_price: "1180",
+            total_price: "2022",
+            last_refreshed: "2025-08-01T00:00:00Z",
+          },
+        ],
+      }),
+    },
+  },
+}));
+
+describe("Dashboard (Aurora)", () => {
+  it("renders the trip columns, violet ACTIVE + amber PAUSED chips, and the pinned footer", async () => {
+    render(<DashboardPage />);
+    await waitFor(() => expect(screen.getByText("Test 2")).toBeInTheDocument());
+    for (const h of ["Trip", "Route", "Dates", "Flight", "Hotel", "Total", "Status"]) {
+      expect(
+        screen.getAllByText(new RegExp(`^${h}`, "i")).length,
+      ).toBeGreaterThan(0);
+    }
+    expect(screen.getByText("ACTIVE")).toHaveClass("aurora-chip-active");
+    expect(screen.getByText("PAUSED")).toHaveClass("aurora-chip-paused");
+    expect(screen.getByText("$789")).toBeInTheDocument();
+    expect(screen.getByText(/Showing 2 of 2 trips/i)).toBeInTheDocument();
+    expect(screen.getByText(/refresh daily at 6:00 AM/i)).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/__tests__/settings-aurora.test.tsx
+++ b/apps/web/src/__tests__/settings-aurora.test.tsx
@@ -1,0 +1,26 @@
+import { render, screen } from "@testing-library/react";
+import SettingsPage from "@/app/trips/settings/page";
+
+jest.mock("next/navigation", () => ({ useRouter: () => ({ push: jest.fn() }) }));
+jest.mock("@/context/AuthContext", () => ({
+  useAuth: () => ({
+    user: { id: "u1", email: "a@b.com", email_notifications_enabled: true },
+    isLoading: false,
+    refreshUser: jest.fn(),
+  }),
+}));
+jest.mock("@/lib/api", () => ({ api: { users: { updatePreferences: jest.fn() } } }));
+
+describe("Settings (Aurora)", () => {
+  it("shows Email (on) and SMS (off) toggles and no Trip members section", () => {
+    render(<SettingsPage />);
+    expect(screen.getByText("Notifications")).toBeInTheDocument();
+    const email = screen.getByRole("switch", { name: /email/i });
+    expect(email).toBeChecked();
+    const sms = screen.getByRole("switch", { name: /sms/i });
+    expect(sms).not.toBeChecked();
+    expect(sms).toBeDisabled();
+    expect(screen.queryByText(/trip members/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/sharing/i)).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/__tests__/sign-in-aurora.test.tsx
+++ b/apps/web/src/__tests__/sign-in-aurora.test.tsx
@@ -1,0 +1,18 @@
+import { render, screen } from "@testing-library/react";
+import HomePage from "@/app/page";
+
+jest.mock("@/lib/navigation", () => ({ redirectTo: jest.fn() }));
+
+describe("Sign-in (Aurora)", () => {
+  it("renders the eyebrow, gradient H1 line, feature row, two stats, and the no-passwords caption", () => {
+    render(<HomePage />);
+    expect(screen.getByText("Date-Range Optimizer")).toBeInTheDocument();
+    expect(screen.getByText(/vacation window/i)).toBeInTheDocument();
+    expect(screen.getByText(/Flight combinations/i)).toBeInTheDocument();
+    expect(screen.getByText(/Hotel matching/i)).toBeInTheDocument();
+    expect(screen.getByText(/Price alerts/i)).toBeInTheDocument();
+    expect(screen.getByText("$186")).toBeInTheDocument();
+    expect(screen.getByText("90+")).toBeInTheDocument();
+    expect(screen.getByText(/never store passwords/i)).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/__tests__/sign-in-aurora.test.tsx
+++ b/apps/web/src/__tests__/sign-in-aurora.test.tsx
@@ -8,8 +8,8 @@ describe("Sign-in (Aurora)", () => {
     render(<HomePage />);
     expect(screen.getByText("Date-Range Optimizer")).toBeInTheDocument();
     expect(screen.getByText(/vacation window/i)).toBeInTheDocument();
-    expect(screen.getByText(/Flight combinations/i)).toBeInTheDocument();
-    expect(screen.getByText(/Hotel matching/i)).toBeInTheDocument();
+    expect(screen.getByText("Flights")).toBeInTheDocument();
+    expect(screen.getByText("Hotels")).toBeInTheDocument();
     expect(screen.getByText(/Price alerts/i)).toBeInTheDocument();
     expect(screen.getByText("$186")).toBeInTheDocument();
     expect(screen.getByText("90+")).toBeInTheDocument();

--- a/apps/web/src/__tests__/trip-detail-selection.test.tsx
+++ b/apps/web/src/__tests__/trip-detail-selection.test.tsx
@@ -1,0 +1,153 @@
+import { act, render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type React from "react";
+import { Suspense } from "react";
+
+jest.mock("next/navigation", () => ({ useRouter: () => ({ push: jest.fn() }) }));
+jest.mock("@/lib/sse-provider", () => ({ useSSEContextOptional: () => null }));
+
+// Mock recharts so the chart renders cheaply in jsdom.
+jest.mock("recharts", () => ({
+  LineChart: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="line-chart">{children}</div>
+  ),
+  Line: () => <div data-testid="chart-line" />,
+  XAxis: () => null,
+  YAxis: () => null,
+  CartesianGrid: () => null,
+}));
+jest.mock("@/components/ui/chart", () => ({
+  ChartContainer: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="chart-container">{children}</div>
+  ),
+  ChartTooltip: () => null,
+  ChartTooltipContent: () => null,
+}));
+
+const snapshot = {
+  id: "s1", created_at: "2025-08-01T00:00:00Z",
+  flight_price: "142", hotel_price: "538", total_price: "680",
+  flight_offers: [
+    { id: "as", airline_code: "AS", price: "177", stops: 0,
+      itineraries: [{ direction: "outbound", stops: 0, segments: [
+        { carrier_code: "AS", flight_number: "AS1", departure_airport: "SFO", arrival_airport: "RDM",
+          departure_time: "2025-08-22T07:05:00", arrival_time: "2025-08-22T09:00:00", duration_minutes: 115 }] }] },
+    { id: "ua", airline_code: "UA", price: "142", stops: 1,
+      itineraries: [{ direction: "outbound", stops: 1, segments: [
+        { carrier_code: "UA", flight_number: "UA508", departure_airport: "SFO", arrival_airport: "DEN",
+          departure_time: "2025-08-22T06:00:00", arrival_time: "2025-08-22T09:30:00", duration_minutes: 210 },
+        { carrier_code: "AS", flight_number: "AS2201", departure_airport: "DEN", arrival_airport: "RDM",
+          departure_time: "2025-08-22T10:40:00", arrival_time: "2025-08-22T12:10:00", duration_minutes: 90 }] }] },
+    { id: "dl", airline_code: "DL", price: "142", stops: 0,
+      itineraries: [{ direction: "outbound", stops: 0, segments: [
+        { carrier_code: "DL", flight_number: "DL77", departure_airport: "SFO", arrival_airport: "RDM",
+          departure_time: "2025-08-22T08:00:00", arrival_time: "2025-08-22T10:00:00", duration_minutes: 120 }] }] },
+  ],
+  hotel_offers: [
+    { id: "river", name: "Riverhouse", price: "612", rating: 4 },
+    { id: "eviva", name: "Eviva", price: "538", rating: 3 },
+  ],
+};
+
+const trip = {
+  id: "t1", name: "Test 2", origin_airport: "SFO", destination_code: "RDM",
+  depart_date: "2025-08-22", return_date: "2025-08-26", status: "active",
+  is_round_trip: true, adults: 2,
+  current_flight_price: "142", current_hotel_price: "538", total_price: "680",
+  hotel_prefs: { rooms: 1 }, track_flights: true, track_hotels: true,
+};
+
+jest.mock("@/lib/api", () => {
+  class ApiError extends Error {
+    status = 0;
+    detail = "";
+  }
+  return {
+    ApiError,
+    api: {
+      trips: {
+        getDetails: jest.fn(async () => ({ data: { trip, price_history: [snapshot] } })),
+      },
+    },
+  };
+});
+
+// Import after mocks.
+import TripDetailPage from "@/app/trips/[tripId]/page";
+
+async function renderPage() {
+  await act(async () => {
+    render(
+      <Suspense fallback={<div>Loading…</div>}>
+        <TripDetailPage params={Promise.resolve({ tripId: "t1" })} />
+      </Suspense>,
+    );
+  });
+}
+
+// The accessible name of each flight radio leads with the operating airline
+// name. We match by that name but skip the multi-carrier "Operated by …"
+// subtitle (which can mention a second airline) so each airline resolves to a
+// single row.
+function findFlightRadio(name: RegExp): HTMLElement {
+  const radios = screen.getAllByRole("radio");
+  const matches = radios.filter((r) => {
+    const text = r.textContent ?? "";
+    const primary = text.split("Operated by")[0];
+    return name.test(primary);
+  });
+  if (matches.length !== 1) {
+    throw new Error(`Expected exactly one flight radio for ${name}, found ${matches.length}`);
+  }
+  return matches[0];
+}
+
+async function selectFlight(name: RegExp) {
+  await userEvent.click(findFlightRadio(name));
+}
+async function selectHotel(name: RegExp) {
+  // Hotels live behind the Hotels tab; switch to it before selecting.
+  await userEvent.click(screen.getByRole("button", { name: /^Hotels$/ }));
+  await userEvent.click(screen.getByRole("radio", { name }));
+}
+
+describe("Trip detail selection → total (verified)", () => {
+  it("Alaska (non-stop) + Riverhouse = $789", async () => {
+    await renderPage();
+    await waitFor(() => expect(screen.getByText("Test 2")).toBeInTheDocument());
+    await selectFlight(/Alaska/i);
+    await selectHotel(/Riverhouse/i);
+    const total = screen.getByTestId("trip-total");
+    expect(within(total).getByText("$789")).toBeInTheDocument();
+    expect(screen.getByTestId("now-badge")).toHaveTextContent("Now $789");
+  });
+
+  it("United (1-stop) + Riverhouse = $754", async () => {
+    await renderPage();
+    await waitFor(() => expect(screen.getByText("Test 2")).toBeInTheDocument());
+    await selectFlight(/United/i);
+    await selectHotel(/Riverhouse/i);
+    expect(within(screen.getByTestId("trip-total")).getByText("$754")).toBeInTheDocument();
+    expect(screen.getByTestId("now-badge")).toHaveTextContent("Now $754");
+  });
+
+  it("Delta + Eviva = $680", async () => {
+    await renderPage();
+    await waitFor(() => expect(screen.getByText("Test 2")).toBeInTheDocument());
+    await selectFlight(/Delta/i);
+    await selectHotel(/Eviva/i);
+    expect(within(screen.getByTestId("trip-total")).getByText("$680")).toBeInTheDocument();
+    expect(screen.getByTestId("now-badge")).toHaveTextContent("Now $680");
+  });
+
+  it("re-tapping the expanded flight collapses it but keeps it selected", async () => {
+    await renderPage();
+    await waitFor(() => expect(screen.getByText("Test 2")).toBeInTheDocument());
+    const alaska = findFlightRadio(/Alaska/i);
+    await userEvent.click(alaska);
+    expect(alaska).toHaveAttribute("aria-expanded", "true");
+    await userEvent.click(alaska);
+    expect(alaska).toHaveAttribute("aria-expanded", "false");
+    expect(alaska).toHaveAttribute("aria-checked", "true");
+  });
+});

--- a/apps/web/src/__tests__/trip-detail.test.tsx
+++ b/apps/web/src/__tests__/trip-detail.test.tsx
@@ -465,13 +465,15 @@ describe("TripDetailPage", () => {
         expect(screen.getAllByText("City Hotel").length).toBeGreaterThanOrEqual(1);
       });
 
-      // Click on a hotel to select it - this covers the onSelectHotel callback
-      const hotelButton = screen.getByRole("button", { name: /City Hotel/ });
+      // Click on a hotel to select it - this covers the onSelectHotel callback.
+      // Hotel rows are now radio controls (single-select).
+      const hotelButton = screen.getByRole("radio", { name: /City Hotel/ });
       await user.click(hotelButton);
 
-      // Verify the hotel button was clickable (the callback was called)
-      // The actual state change is internal, but we can verify no error occurred
-      expect(hotelButton).toBeInTheDocument();
+      // The selected hotel radio reflects the selection state.
+      await waitFor(() => {
+        expect(hotelButton).toHaveAttribute("aria-checked", "true");
+      });
     });
 
     it("displays flights list", async () => {
@@ -482,9 +484,9 @@ describe("TripDetailPage", () => {
       await waitFor(() => {
         // Flights section header
         expect(screen.getByText("Flights")).toBeInTheDocument();
-        // Collapsed card shows price and Direct badge (stops === 0 for basePriceHistory flight)
+        // Collapsed card shows price and a NON-STOP badge (stops === 0 for basePriceHistory flight)
         expect(screen.getAllByText("$250").length).toBeGreaterThanOrEqual(1);
-        expect(screen.getByText("Direct")).toBeInTheDocument();
+        expect(screen.getByText("NON-STOP")).toBeInTheDocument();
       });
     });
 
@@ -690,13 +692,12 @@ describe("TripDetailPage", () => {
 
       // Wait for the flight card to render - collapsed view shows stops and price
       await waitFor(() => {
-        expect(screen.getByText("1 stop")).toBeInTheDocument();
+        expect(screen.getByText("1 STOP")).toBeInTheDocument();
         expect(screen.getAllByText("$250").length).toBeGreaterThanOrEqual(1);
       });
 
-      // Click on the element containing "1 stop" to expand the card
-      const stopsBadge = screen.getByText("1 stop");
-      const cardHeader = stopsBadge.closest("button");
+      // Clicking the flight row (a radio) selects it and toggles its expansion.
+      const cardHeader = screen.getByText("1 STOP").closest("button");
       expect(cardHeader).toBeTruthy();
       if (cardHeader) {
         await user.click(cardHeader);
@@ -766,8 +767,8 @@ describe("TripDetailPage", () => {
       });
 
       await waitFor(() => {
-        // The expandable card shows "2 stops" in the collapsed header
-        expect(screen.getByText("2 stops")).toBeInTheDocument();
+        // The expandable card shows "2 STOPS" in the collapsed header
+        expect(screen.getByText("2 STOPS")).toBeInTheDocument();
         // Duration is shown when expanded, price is shown in collapsed view
         expect(screen.getAllByText("$200").length).toBeGreaterThanOrEqual(1);
       });
@@ -833,23 +834,23 @@ describe("TripDetailPage", () => {
         render(<TestWrapper tripId="test-trip" />);
       });
 
-      // Wait for the card to render, then expand it
+      // Wait for the card to render, then expand it. With a 2-segment outbound
+      // the stops badge names the connecting airport: "1 STOP · DEN".
       await waitFor(() => {
-        expect(screen.getByText("1 stop")).toBeInTheDocument();
+        expect(screen.getByText("1 STOP · DEN")).toBeInTheDocument();
       });
 
-      const stopsBadge = screen.getByText("1 stop");
-      const cardHeader = stopsBadge.closest("button");
+      const cardHeader = screen.getByText("1 STOP · DEN").closest("button");
       expect(cardHeader).toBeTruthy();
       if (cardHeader) {
         await user.click(cardHeader);
       }
 
-      // Expanded view should show both segments and layover info
+      // Expanded view should show both segments and layover info (city + code).
       await waitFor(() => {
         expect(screen.getByText("UA100")).toBeInTheDocument();
         expect(screen.getByText("UA200")).toBeInTheDocument();
-        expect(screen.getByText(/layover in DEN/)).toBeInTheDocument();
+        expect(screen.getByText(/layover in Denver \(DEN\)/)).toBeInTheDocument();
       });
     });
 
@@ -922,9 +923,8 @@ describe("TripDetailPage", () => {
         expect(screen.getAllByText("$250").length).toBeGreaterThanOrEqual(1);
       });
 
-      // Find and click the card header to expand
-      const stopsBadge = screen.getByText("1 stop");
-      const cardHeader = stopsBadge.closest("button");
+      // Find and click the flight row (radio) to select + expand it.
+      const cardHeader = screen.getByText("1 STOP").closest("button");
       expect(cardHeader).toBeTruthy();
       if (cardHeader) {
         await user.click(cardHeader);
@@ -935,15 +935,16 @@ describe("TripDetailPage", () => {
         expect(screen.getByText("Outbound")).toBeInTheDocument();
       });
 
-      // Click again to collapse
+      // Click again to collapse — selection is retained, only expansion toggles.
       if (cardHeader) {
         await user.click(cardHeader);
       }
 
-      // Outbound label should disappear
+      // Outbound label should disappear, but the row stays selected.
       await waitFor(() => {
         expect(screen.queryByText("Outbound")).not.toBeInTheDocument();
       });
+      expect(cardHeader).toHaveAttribute("aria-checked", "true");
     });
 
     it("shows empty state when no hotel offers", async () => {

--- a/apps/web/src/__tests__/trip-form-flight-prefs-section.test.tsx
+++ b/apps/web/src/__tests__/trip-form-flight-prefs-section.test.tsx
@@ -56,10 +56,14 @@ describe("FlightPrefsSection", () => {
     expect(screen.getByText("Flight Preferences")).toBeInTheDocument();
     expect(screen.getByPlaceholderText("Type airline codes (e.g., UA, AA, DL)")).toBeInTheDocument();
 
-    await user.click(screen.getByTestId("select-economy"));
-    await user.click(screen.getByTestId("select-any"));
+    // Cabin class is rendered as pill chip buttons (aria-pressed marks selection).
+    const economyChip = screen.getByRole("button", { name: /^Economy$/i });
+    expect(economyChip).toHaveAttribute("aria-pressed", "true");
 
-    expect(onCabinChange).toHaveBeenCalledWith("economy");
+    await user.click(screen.getByRole("button", { name: /Premium Economy/i }));
+    expect(onCabinChange).toHaveBeenCalledWith("premium_economy");
+
+    await user.click(screen.getByTestId("select-any"));
     expect(onStopsModeChange).toHaveBeenCalledWith("any");
   });
 });

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -238,15 +238,14 @@ body {
 
 /* Primary button - gradient with glow */
 .btn-primary {
-  background: linear-gradient(135deg, hsl(262 83% 58%) 0%, hsl(262 83% 48%) 100%);
+  background: var(--aurora-violet);
   color: white;
   border: none;
-  box-shadow:
-    0 2px 8px rgba(124, 58, 237, 0.3),
-    0 1px 2px rgba(0, 0, 0, 0.1);
+  box-shadow: var(--aurora-shadow-btn);
 }
 
 .btn-primary:hover {
+  background: var(--aurora-violet-deep);
   box-shadow:
     0 4px 16px rgba(124, 58, 237, 0.4),
     0 2px 4px rgba(0, 0, 0, 0.1);
@@ -255,20 +254,16 @@ body {
 
 /* Outline button - frosted glass */
 .btn-outline {
-  background: var(--glass-bg);
-  backdrop-filter: blur(8px);
-  -webkit-backdrop-filter: blur(8px);
-  border: 1px solid var(--glass-border);
-  color: var(--ink);
-  box-shadow:
-    0 1px 3px rgba(0, 0, 0, 0.05),
-    inset 0 1px 0 rgba(255, 255, 255, 0.1);
+  background: var(--aurora-card);
+  border: 1px solid var(--aurora-hairline-2);
+  color: var(--aurora-ink);
+  box-shadow: none;
   transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
 }
 
 .btn-outline:hover {
-  background: rgba(255, 255, 255, 0.9);
-  border-color: rgba(0, 0, 0, 0.12);
+  background: var(--aurora-surface-2);
+  border-color: var(--aurora-selected-border);
   box-shadow:
     0 4px 12px rgba(0, 0, 0, 0.08),
     inset 0 1px 0 rgba(255, 255, 255, 0.5);

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -72,6 +72,44 @@
   --chart-3: 340 75% 55%;
   --chart-4: 30 80% 55%;
   --chart-5: 160 60% 45%;
+
+  /* ===== Aurora design tokens (light theme; source of truth) ===== */
+  --aurora-violet: #7C3AED;
+  --aurora-violet-deep: #6D28D9;
+  --aurora-pink: #EC4899;
+  --aurora-pink-light: #F9A8D4;
+  --aurora-cyan: #22D3EE;
+  --aurora-page: #FAF8FF;
+  --aurora-surface: #F4F1FC;
+  --aurora-surface-2: #F8F5FE;
+  --aurora-chip: #EDE9FE;
+  --aurora-card: #FFFFFF;
+  --aurora-hairline: #F1EEF8;
+  --aurora-hairline-2: #ECE8F5;
+  --aurora-selected-border: #C9B8F5;
+  --aurora-ink: #1A1A2E;
+  --aurora-body: #4A4660;
+  --aurora-body-2: #6B6680;
+  --aurora-muted: #8B86A0;
+  --aurora-faint: #BDB6D4;
+  --aurora-success: #059669;
+  --aurora-success-bg: #ECFDF5;
+  --aurora-warn: #9A7B18;
+  --aurora-warn-bg: #FEF6DD;
+  --aurora-layover: #C98A3A;
+  --aurora-layover-bg: #FDF6E9;
+  --aurora-layover-border: #F6E7C8;
+  --aurora-star: #F5A623;
+  --aurora-star-empty: #E0D9EF;
+  --aurora-grad-primary: linear-gradient(135deg, #A78BFA, #7C3AED);
+  --aurora-grad-total: linear-gradient(135deg, #7C3AED, #9333EA);
+  --aurora-shadow-card: 0 16px 50px rgba(60, 40, 120, .13);
+  --aurora-shadow-soft: 0 2px 10px rgba(60, 40, 120, .04);
+  --aurora-shadow-btn: 0 5px 14px rgba(124, 58, 237, .32);
+  --aurora-shadow-total: 0 8px 22px rgba(124, 58, 237, .30);
+  --aurora-radius-card: 15px;
+  --aurora-radius-inner: 12px;
+  --aurora-radius-chip: 9px;
 }
 
 /* Dark mode theme - active from 6pm to 8am */
@@ -480,4 +518,74 @@ button[role="combobox"] svg {
 
 .dark button[role="combobox"] svg {
   color: rgba(255, 255, 255, 0.5) !important;
+}
+
+/* ============================================
+   AURORA UTILITY CLASSES (light theme)
+   ============================================ */
+.aurora-card {
+  background: var(--aurora-card);
+  border: 1px solid var(--aurora-hairline);
+  border-radius: var(--aurora-radius-card);
+  box-shadow: var(--aurora-shadow-card);
+}
+.aurora-hairline { border: 1px solid var(--aurora-hairline); }
+
+.aurora-logo {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--aurora-grad-primary);
+  color: #fff;
+  border-radius: 11px;
+  box-shadow: var(--aurora-shadow-btn);
+}
+.aurora-avatar {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--aurora-grad-primary);
+  color: #fff;
+  border-radius: 50%;
+  font-weight: 700;
+  letter-spacing: .02em;
+}
+
+.aurora-total-card {
+  background: var(--aurora-grad-total);
+  color: #fff;
+  border-radius: var(--aurora-radius-inner);
+  box-shadow: var(--aurora-shadow-total);
+}
+
+.aurora-chip-active,
+.aurora-chip-paused,
+.aurora-chip-nonstop,
+.aurora-chip-stop {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  border-radius: 999px;
+  padding: 2px 9px;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: .06em;
+  text-transform: uppercase;
+}
+.aurora-chip-active { background: var(--aurora-chip); color: var(--aurora-violet-deep); }
+.aurora-chip-paused { background: var(--aurora-warn-bg); color: var(--aurora-warn); }
+.aurora-chip-nonstop { background: var(--aurora-success-bg); color: var(--aurora-success); }
+.aurora-chip-stop { background: var(--aurora-warn-bg); color: var(--aurora-warn); }
+
+.aurora-layover-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  background: var(--aurora-layover-bg);
+  color: var(--aurora-layover);
+  border: 1px solid var(--aurora-layover-border);
+  border-radius: 999px;
+  padding: 3px 10px;
+  font-size: 11px;
+  font-weight: 600;
 }

--- a/apps/web/src/app/layout.module.css
+++ b/apps/web/src/app/layout.module.css
@@ -1,6 +1,6 @@
 .footer {
   font-size: 0.85rem;
-  color: var(--ink-muted);
+  color: var(--aurora-muted);
   text-align: center;
   display: flex;
   align-items: center;
@@ -13,5 +13,5 @@
 }
 
 .divider {
-  color: var(--border);
+  color: var(--aurora-hairline);
 }

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -16,7 +16,7 @@ const display = Space_Grotesk({
 const body = Manrope({
   subsets: ["latin"],
   variable: "--font-body",
-  weight: ["400", "600"],
+  weight: ["400", "500", "600", "700", "800"],
 });
 
 export const metadata: Metadata = {

--- a/apps/web/src/app/page.module.css
+++ b/apps/web/src/app/page.module.css
@@ -4,6 +4,7 @@
   display: flex;
   flex-direction: column;
   overflow: hidden;
+  background: var(--aurora-page);
 }
 
 /* Decorative gradient blobs for depth */
@@ -24,8 +25,7 @@
   border-radius: 50%;
   background: radial-gradient(
     circle,
-    rgba(255, 107, 107, 0.25) 0%,
-    rgba(254, 202, 87, 0.15) 50%,
+    rgba(124, 58, 237, 0.18) 0%,
     transparent 70%
   );
   filter: blur(40px);
@@ -41,8 +41,7 @@
   border-radius: 50%;
   background: radial-gradient(
     circle,
-    rgba(102, 126, 234, 0.3) 0%,
-    rgba(118, 75, 162, 0.2) 50%,
+    rgba(236, 72, 153, 0.18) 0%,
     transparent 70%
   );
   filter: blur(50px);
@@ -58,7 +57,7 @@
   border-radius: 50%;
   background: radial-gradient(
     circle,
-    rgba(52, 152, 219, 0.15) 0%,
+    rgba(34, 211, 238, 0.18) 0%,
     transparent 60%
   );
   filter: blur(30px);
@@ -97,7 +96,8 @@
   max-width: 1200px;
   margin: 0 auto;
   display: grid;
-  gap: 4rem;
+  grid-template-columns: 1.05fr 0.95fr;
+  gap: 48px;
   align-items: center;
 }
 
@@ -110,7 +110,7 @@
 
 .badge {
   align-self: flex-start;
-  background: linear-gradient(135deg, hsl(var(--primary)), hsl(var(--accent)));
+  background: linear-gradient(135deg, var(--aurora-violet), var(--aurora-pink));
   color: white;
   font-weight: 600;
   letter-spacing: 0.04em;
@@ -123,25 +123,27 @@
 
 .title {
   font-family: var(--font-display), "Space Grotesk", "Helvetica Neue", sans-serif;
-  font-size: clamp(2.5rem, 5vw, 4rem);
   font-weight: 800;
-  line-height: 1.1;
+  font-size: 28px;
+  line-height: 1.15;
   margin: 0;
   letter-spacing: -0.02em;
-  color: var(--ink);
+  color: var(--aurora-ink);
 }
 
 .titleAccent {
-  background: linear-gradient(135deg, hsl(var(--primary)) 0%, hsl(var(--accent)) 100%);
+  background: linear-gradient(135deg, var(--aurora-violet), var(--aurora-pink));
   -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
   background-clip: text;
+  -webkit-text-fill-color: transparent;
+  color: transparent;
 }
 
 .tagline {
   font-size: 1.2rem;
   line-height: 1.7;
-  color: var(--ink-muted);
+  color: var(--aurora-body);
+  font-weight: 500;
   max-width: 480px;
   margin: 0;
 }
@@ -153,11 +155,10 @@
   gap: 1.25rem;
   flex-wrap: wrap;
   padding: 1.25rem 1.5rem;
-  background: var(--glass-bg);
-  backdrop-filter: blur(12px);
-  border: 1px solid var(--glass-border);
-  border-radius: 16px;
-  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.06);
+  background: var(--aurora-card);
+  border: 1px solid var(--aurora-hairline);
+  border-radius: var(--aurora-radius-card);
+  box-shadow: var(--aurora-shadow-card);
   width: fit-content;
 }
 
@@ -167,23 +168,23 @@
   gap: 0.6rem;
   font-size: 0.95rem;
   font-weight: 500;
-  color: var(--ink);
+  color: var(--aurora-ink);
 }
 
 .featureIcon {
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 36px;
-  height: 36px;
+  width: 40px;
+  height: 40px;
   border-radius: 10px;
-  background: linear-gradient(135deg, hsl(var(--primary) / 0.15), hsl(var(--accent) / 0.1));
-  color: hsl(var(--primary));
+  background: var(--aurora-surface);
+  color: var(--aurora-violet);
 }
 
 .separator {
   height: 28px;
-  background: var(--border);
+  background: var(--aurora-hairline-2);
 }
 
 /* Stats row */
@@ -200,18 +201,15 @@
 }
 
 .statValue {
-  font-size: 2rem;
+  font-size: 22px;
   font-weight: 800;
   letter-spacing: -0.02em;
-  background: linear-gradient(135deg, hsl(var(--primary)), hsl(var(--accent)));
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  background-clip: text;
+  color: var(--aurora-ink);
 }
 
 .statLabel {
   font-size: 0.85rem;
-  color: var(--ink-muted);
+  color: var(--aurora-muted);
   text-transform: uppercase;
   letter-spacing: 0.06em;
 }
@@ -223,11 +221,11 @@
 }
 
 .ctaCard {
-  background: var(--glass-bg);
-  backdrop-filter: blur(12px);
-  border: 1px solid var(--glass-border);
-  border-radius: 16px;
-  padding: 2rem;
+  background: var(--aurora-card);
+  border: 1px solid var(--aurora-hairline);
+  border-radius: var(--aurora-radius-card);
+  box-shadow: var(--aurora-shadow-card);
+  padding: 28px;
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -238,21 +236,20 @@
 .ctaCard h2 {
   font-size: 1.5rem;
   font-weight: 700;
-  color: var(--ink);
+  color: var(--aurora-ink);
 }
 
 .ctaCard p {
-  color: var(--ink-muted);
+  color: var(--aurora-body);
   margin-bottom: 0.5rem;
 }
 
 .oauthNote {
-  font-size: 0.8rem;
-  color: var(--ink-muted);
+  font-size: 12px;
+  color: var(--aurora-muted);
   margin-top: 0.5rem;
   margin-bottom: 0;
 }
-
 
 /* Footer */
 .footerWrap {
@@ -263,14 +260,28 @@
   padding: 1.25rem 2rem 1.75rem;
 }
 
-/* Responsive */
-@media (min-width: 720px) {
+/* Responsive: half-width reflow */
+@media (max-width: 820px) {
   .heroGrid {
-    grid-template-columns: 1fr 360px; /* Left column flexible, right card fixed */
+    grid-template-columns: 1fr;
+  }
+
+  .heroContent {
+    align-items: center;
+    text-align: center;
+  }
+
+  .badge {
+    align-self: center;
+  }
+
+  .featuresRow {
+    width: 100%;
+    justify-content: center;
   }
 
   .heroCard {
-    justify-self: end;
+    justify-self: center;
   }
 }
 
@@ -281,7 +292,7 @@
 
   .featuresRow {
     flex-direction: column;
-    align-items: flex-start;
+    align-items: center;
     gap: 1rem;
     width: 100%;
   }
@@ -292,5 +303,6 @@
 
   .statsRow {
     gap: 1.5rem;
+    justify-content: center;
   }
 }

--- a/apps/web/src/app/page.module.css
+++ b/apps/web/src/app/page.module.css
@@ -124,8 +124,8 @@
 .title {
   font-family: var(--font-display), "Space Grotesk", "Helvetica Neue", sans-serif;
   font-weight: 800;
-  font-size: 28px;
-  line-height: 1.15;
+  font-size: clamp(2.25rem, 3vw, 2.5rem);
+  line-height: 1.1;
   margin: 0;
   letter-spacing: -0.02em;
   color: var(--aurora-ink);
@@ -153,7 +153,7 @@
   display: flex;
   align-items: center;
   gap: 1.25rem;
-  flex-wrap: wrap;
+  flex-wrap: nowrap;
   padding: 1.25rem 1.5rem;
   background: var(--aurora-card);
   border: 1px solid var(--aurora-hairline);
@@ -228,9 +228,22 @@
   padding: 28px;
   display: flex;
   flex-direction: column;
+  align-items: stretch;
+  gap: 0.85rem;
+  text-align: left;
+}
+
+.cardLogo {
+  display: inline-flex;
   align-items: center;
-  gap: 1rem;
-  text-align: center;
+  justify-content: center;
+  width: 44px;
+  height: 44px;
+  border-radius: 12px;
+  background: var(--aurora-grad-primary);
+  color: #fff;
+  box-shadow: var(--aurora-shadow-btn);
+  margin-bottom: 0.25rem;
 }
 
 .ctaCard h2 {
@@ -241,13 +254,14 @@
 
 .ctaCard p {
   color: var(--aurora-body);
-  margin-bottom: 0.5rem;
+  margin: 0;
 }
 
 .oauthNote {
   font-size: 12px;
   color: var(--aurora-muted);
-  margin-top: 0.5rem;
+  text-align: center;
+  margin-top: 0.35rem;
   margin-bottom: 0;
 }
 

--- a/apps/web/src/app/page.test.tsx
+++ b/apps/web/src/app/page.test.tsx
@@ -17,8 +17,8 @@ describe("HomePage", () => {
   it("renders the main heading", () => {
     render(<HomePage />);
 
-    expect(screen.getByText("Find Your Cheapest")).toBeInTheDocument();
-    expect(screen.getByText("Vacation Window")).toBeInTheDocument();
+    expect(screen.getByText("Find your cheapest")).toBeInTheDocument();
+    expect(screen.getByText("vacation window")).toBeInTheDocument();
   });
 
   it("renders the badge", () => {

--- a/apps/web/src/app/page.test.tsx
+++ b/apps/web/src/app/page.test.tsx
@@ -40,8 +40,8 @@ describe("HomePage", () => {
   it("renders the feature items", () => {
     render(<HomePage />);
 
-    expect(screen.getByText("Flight combinations")).toBeInTheDocument();
-    expect(screen.getByText("Hotel matching")).toBeInTheDocument();
+    expect(screen.getByText("Flights")).toBeInTheDocument();
+    expect(screen.getByText("Hotels")).toBeInTheDocument();
     expect(screen.getByText("Price alerts")).toBeInTheDocument();
   });
 

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -45,14 +45,14 @@ export default function HomePage() {
                 <div className={styles.featureIcon}>
                   <Plane size={20} />
                 </div>
-                <span>Flight combinations</span>
+                <span>Flights</span>
               </div>
               <Separator orientation="vertical" className={styles.separator} />
               <div className={styles.featureItem}>
                 <div className={styles.featureIcon}>
                   <Building2 size={20} />
                 </div>
-                <span>Hotel matching</span>
+                <span>Hotels</span>
               </div>
               <Separator orientation="vertical" className={styles.separator} />
               <div className={styles.featureItem}>
@@ -81,9 +81,16 @@ export default function HomePage() {
           {/* Right column: Sign-in card */}
           <div className={styles.heroCard}>
             <div className={styles.ctaCard}>
+              <div className={styles.cardLogo} aria-hidden="true">
+                <Plane size={22} />
+              </div>
               <h2>Ready to get started?</h2>
               <p>Sign in to create your first trip and start tracking prices.</p>
-              <GoogleButton onClick={handleSignIn} />
+              <GoogleButton
+                type="light"
+                onClick={handleSignIn}
+                style={{ width: "100%", borderRadius: 10 }}
+              />
               <p className={styles.oauthNote}>
                 Google OAuth only. We never store passwords.
               </p>

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -29,9 +29,9 @@ export default function HomePage() {
             <Badge className={styles.badge}>Date-Range Optimizer</Badge>
 
             <h1 className={styles.title}>
-              Find Your Cheapest
+              Find your cheapest
               <br />
-              <span className={styles.titleAccent}>Vacation Window</span>
+              <span className={styles.titleAccent}>vacation window</span>
             </h1>
 
             <p className={styles.tagline}>

--- a/apps/web/src/app/trips/[tripId]/page.module.css
+++ b/apps/web/src/app/trips/[tripId]/page.module.css
@@ -200,6 +200,129 @@
   }
 }
 
+/* Aurora offers layout — chart left, offers right; stacks below 820px. */
+.offersGrid {
+  display: grid;
+  grid-template-columns: 1.05fr 0.95fr;
+  gap: 16px;
+  flex: 1;
+  min-height: 0;
+}
+
+@media (max-width: 820px) {
+  .offersGrid {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* Sticky header + price summary region so the selection/total stays visible. */
+.stickyRegion {
+  position: sticky;
+  top: 0;
+  z-index: 5;
+  background: var(--aurora-page);
+}
+
+/* Total chip — gradient pill that wraps the running total. */
+.auroraTotalCard {
+  background: var(--aurora-grad-total);
+  border-radius: var(--aurora-radius-inner);
+  box-shadow: var(--aurora-shadow-total);
+  padding: 0.375rem 0.875rem;
+  color: #fff;
+}
+
+.auroraTotalCard .priceTotalValue {
+  color: #fff;
+}
+
+/* "Now $X" badge anchored over the latest chart point. */
+.chartWrap {
+  position: relative;
+  flex: 1;
+  min-height: 0;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+}
+
+.nowBadge {
+  position: absolute;
+  top: 0;
+  right: 0;
+  z-index: 2;
+  display: inline-flex;
+  align-items: center;
+  padding: 2px 10px;
+  border-radius: 9999px;
+  background: var(--aurora-grad-total);
+  color: #fff;
+  font-size: 0.75rem;
+  font-weight: 700;
+  box-shadow: var(--aurora-shadow-total);
+}
+
+/* Multi-carrier flight card accent. */
+.flightCardMulti {
+  border-left: 3px solid var(--aurora-layover);
+}
+
+/* Layover pill — warm Aurora tone. */
+.auroraLayoverPill {
+  display: inline-flex;
+  align-items: center;
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--aurora-layover);
+  background: var(--aurora-layover-bg);
+  border: 1px solid var(--aurora-layover-border);
+  border-radius: 9999px;
+  padding: 2px 10px;
+}
+
+/* Airline cell — chip + name/subtitle stack. */
+.headerAirlineCell {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
+
+.headerAirlineText {
+  display: inline-flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+.headerSubtitle {
+  font-size: 10px;
+  color: var(--aurora-layover);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.stopsBadge {
+  justify-self: center;
+}
+
+/* Selected offer emphasis. */
+.flightCardExpandable.flightCardBest {
+  background: var(--aurora-surface-2);
+  border: 1px solid var(--aurora-selected-border);
+}
+
+.hotelCardCompact.hotelSelected {
+  background: var(--aurora-surface-2);
+  border-color: var(--aurora-selected-border);
+}
+
+.cardPriceSelected,
+.hotelPriceSelected .hotelPerNight {
+  color: var(--aurora-violet);
+  font-weight: 800;
+}
+
 .offersTabs {
   display: flex;
   gap: 0;

--- a/apps/web/src/app/trips/[tripId]/page.tsx
+++ b/apps/web/src/app/trips/[tripId]/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { use, useState, useEffect, useCallback, useMemo, useRef } from "react";
+import React, { use, useReducer, useState, useEffect, useCallback, useMemo, useRef } from "react";
 import { useRouter } from "next/navigation";
 import {
   AlertCircle,
@@ -54,7 +54,64 @@ import {
   hotelStableKey,
   parsePrice,
 } from "@/lib/price-history";
+import {
+  airlineChip,
+  layoverLabel,
+  multiCarrierSubtitle,
+  operatingCarriers,
+  stopsBadge,
+} from "@/lib/aurora";
+import { AirlineChip } from "@/components/aurora/airline-chip";
+import { HotelPhoto } from "@/components/aurora/hotel-photo";
 import styles from "./page.module.css";
+
+/**
+ * Single source of truth for which flight/hotel are selected and which (if any)
+ * row is expanded. Selecting a row also toggles its expansion; selecting a
+ * different row moves the expansion. This keeps the interactive screen's state
+ * coherent so the selection -> total -> chart recompute stays consistent.
+ */
+type SelectionState = {
+  selectedFlightId: string | null;
+  expandedFlightId: string | null;
+  selectedHotelId: string | null;
+  expandedHotelId: string | null;
+};
+type SelectionAction =
+  | { type: "selectFlight"; id: string }
+  | { type: "selectHotel"; id: string }
+  | { type: "preselect"; flightId: string | null; hotelId: string | null };
+
+function selectionReducer(state: SelectionState, action: SelectionAction): SelectionState {
+  switch (action.type) {
+    case "selectFlight":
+      return {
+        ...state,
+        selectedFlightId: action.id,
+        expandedFlightId: state.expandedFlightId === action.id ? null : action.id,
+      };
+    case "selectHotel":
+      return {
+        ...state,
+        selectedHotelId: action.id,
+        expandedHotelId: state.expandedHotelId === action.id ? null : action.id,
+      };
+    case "preselect":
+      return {
+        selectedFlightId: action.flightId,
+        expandedFlightId: null,
+        selectedHotelId: action.hotelId,
+        expandedHotelId: null,
+      };
+  }
+}
+
+const INITIAL_SELECTION: SelectionState = {
+  selectedFlightId: null,
+  expandedFlightId: null,
+  selectedHotelId: null,
+  expandedHotelId: null,
+};
 
 /**
  * Display label for a flight: all flight numbers across both itineraries.
@@ -102,6 +159,7 @@ function PriceHistoryChart({
   selectedFlightKey,
   selectedFlightLabel,
   showHotel = true,
+  nowTotal,
 }: {
   priceHistory: PriceSnapshot[];
   selectedHotelKey: string | null;
@@ -109,6 +167,7 @@ function PriceHistoryChart({
   selectedFlightKey: string | null;
   selectedFlightLabel?: string;
   showHotel?: boolean;
+  nowTotal?: number | null;
 }) {
   // Collapse to one point per calendar day (cheapest total that day) so long
   // tracking windows stay readable. Carry-forward for selected offers is handled
@@ -124,6 +183,11 @@ function PriceHistoryChart({
       <div className={styles.emptyChart}>
         <TrendingUp className={styles.emptyChartIcon} />
         <p>No price history yet</p>
+        {nowTotal != null && (
+          <span data-testid="now-badge" className={styles.nowBadge}>
+            Now {formatPrice(nowTotal)}
+          </span>
+        )}
       </div>
     );
   }
@@ -141,95 +205,102 @@ function PriceHistoryChart({
   } satisfies ChartConfig;
 
   return (
-    <ChartContainer config={chartConfig} className={styles.chartContainer}>
-      <LineChart
-        accessibilityLayer
-        data={chartData}
-        margin={{ left: 0, right: 8, top: 8, bottom: 0 }}
-      >
-        <CartesianGrid strokeDasharray="3 3" vertical={false} />
-        <XAxis
-          dataKey="label"
-          tickLine={false}
-          axisLine={false}
-          tickMargin={8}
-          fontSize={11}
-          interval="preserveStartEnd"
-          minTickGap={32}
-        />
-        <YAxis
-          tickLine={false}
-          axisLine={false}
-          tickMargin={4}
-          tickFormatter={(v) => `$${v}`}
-          fontSize={11}
-          width={45}
-        />
-        <ChartTooltip
-          cursor={false}
-          content={
-            <ChartTooltipContent
-              formatter={(value, name) => (
-                <span>
-                  {chartConfig[name as keyof typeof chartConfig]?.label}:{" "}
-                  <strong>${Number(value).toLocaleString()}</strong>
-                </span>
-              )}
-            />
-          }
-        />
-        {/* Total — bold solid line, stands out from the pairs */}
-        {showHotel && (
-          <Line
-            dataKey="total"
-            type="monotone"
-            stroke="var(--color-total)"
-            strokeWidth={2.5}
-            dot={{ r: 3 }}
+    <div className={styles.chartWrap}>
+      {nowTotal != null && (
+        <span data-testid="now-badge" className={styles.nowBadge}>
+          Now {formatPrice(nowTotal)}
+        </span>
+      )}
+      <ChartContainer config={chartConfig} className={styles.chartContainer}>
+        <LineChart
+          accessibilityLayer
+          data={chartData}
+          margin={{ left: 0, right: 8, top: 8, bottom: 0 }}
+        >
+          <CartesianGrid strokeDasharray="3 3" vertical={false} />
+          <XAxis
+            dataKey="label"
+            tickLine={false}
+            axisLine={false}
+            tickMargin={8}
+            fontSize={11}
+            interval="preserveStartEnd"
+            minTickGap={32}
           />
-        )}
-        {/* Mins (flight + hotel) — thin dashed lines, no dots */}
-        <Line
-          dataKey="minFlight"
-          type="monotone"
-          stroke="var(--color-minFlight)"
-          strokeWidth={1.5}
-          strokeDasharray="4 4"
-          dot={false}
-        />
-        {showHotel && (
+          <YAxis
+            tickLine={false}
+            axisLine={false}
+            tickMargin={4}
+            tickFormatter={(v) => `$${v}`}
+            fontSize={11}
+            width={45}
+          />
+          <ChartTooltip
+            cursor={false}
+            content={
+              <ChartTooltipContent
+                formatter={(value, name) => (
+                  <span>
+                    {chartConfig[name as keyof typeof chartConfig]?.label}:{" "}
+                    <strong>${Number(value).toLocaleString()}</strong>
+                  </span>
+                )}
+              />
+            }
+          />
+          {/* Total — bold solid line, stands out from the pairs */}
+          {showHotel && (
+            <Line
+              dataKey="total"
+              type="monotone"
+              stroke="var(--color-total)"
+              strokeWidth={2.5}
+              dot={{ r: 3 }}
+            />
+          )}
+          {/* Mins (flight + hotel) — thin dashed lines, no dots */}
           <Line
-            dataKey="minHotel"
+            dataKey="minFlight"
             type="monotone"
-            stroke="var(--color-minHotel)"
+            stroke="var(--color-minFlight)"
             strokeWidth={1.5}
             strokeDasharray="4 4"
             dot={false}
           />
-        )}
-        {/* Selected (flight + hotel) — same color as min, but solid + dots */}
-        {selectedFlightKey && (
-          <Line
-            dataKey="selectedFlight"
-            type="monotone"
-            stroke="var(--color-selectedFlight)"
-            strokeWidth={1.5}
-            dot={{ r: 2.5 }}
-            connectNulls
-          />
-        )}
-        {showHotel && selectedHotelKey && (
-          <Line
-            dataKey="selectedHotel"
-            type="monotone"
-            stroke="var(--color-selectedHotel)"
-            strokeWidth={1.5}
-            dot={{ r: 2.5 }}
-            connectNulls
-          />
-        )}
-      </LineChart>
-    </ChartContainer>
+          {showHotel && (
+            <Line
+              dataKey="minHotel"
+              type="monotone"
+              stroke="var(--color-minHotel)"
+              strokeWidth={1.5}
+              strokeDasharray="4 4"
+              dot={false}
+            />
+          )}
+          {/* Selected (flight + hotel) — same color as min, but solid + dots */}
+          {selectedFlightKey && (
+            <Line
+              dataKey="selectedFlight"
+              type="monotone"
+              stroke="var(--color-selectedFlight)"
+              strokeWidth={1.5}
+              dot={{ r: 2.5 }}
+              connectNulls
+            />
+          )}
+          {showHotel && selectedHotelKey && (
+            <Line
+              dataKey="selectedHotel"
+              type="monotone"
+              stroke="var(--color-selectedHotel)"
+              strokeWidth={1.5}
+              dot={{ r: 2.5 }}
+              connectNulls
+            />
+          )}
+        </LineChart>
+      </ChartContainer>
+    </div>
   );
 }
 
@@ -326,26 +397,13 @@ function ItinerarySection({
         {totalDuration && <span className={styles.itineraryDuration}>{totalDuration} total</span>}
       </div>
       {segments.map((segment, idx) => {
-        // Calculate layover time from previous segment
-        let layover: string | null = null;
-        if (idx > 0) {
-          const prevArrival = segments[idx - 1].arrival_time;
-          const curDeparture = segment.departure_time;
-          if (prevArrival && curDeparture) {
-            const arrDate = new Date(prevArrival);
-            const depDate = new Date(curDeparture);
-            const diffMs = depDate.getTime() - arrDate.getTime();
-            if (diffMs > 0 && !Number.isNaN(diffMs)) {
-              const diffMins = Math.round(diffMs / 60000);
-              layover = formatDuration(diffMins);
-            }
-          }
-        }
+        // Calculate layover label from previous segment (city + code + duration).
+        const layover = idx > 0 ? layoverLabel(segments[idx - 1], segment) : null;
         return (
           <React.Fragment key={`${segment.flight_number || idx}`}>
             {layover && (
               <div className={styles.layoverRow}>
-                <span className={styles.layoverText}>{layover} layover in {segments[idx - 1].arrival_airport || "—"}</span>
+                <span className={styles.auroraLayoverPill}>{layover}</span>
               </div>
             )}
             <SegmentRow segment={segment} />
@@ -370,28 +428,30 @@ function priceOrInfinity(value: string | null | undefined): number {
   return parsePrice(value) ?? Number.POSITIVE_INFINITY;
 }
 
-function preselectCheapest(
+/** Compute the cheapest flight/hotel stable keys from the latest snapshot. */
+function cheapestSelection(
   latest: PriceSnapshot | undefined,
-  setFlight: (key: string | null) => void,
-  setHotel: (key: string | null) => void,
-): void {
-  if (!latest) return;
+): { flightId: string | null; hotelId: string | null } {
+  if (!latest) return { flightId: null, hotelId: null };
+  let flightId: string | null = null;
   const flights = (latest.flight_offers ?? []) as ApiFlightOffer[];
   if (flights.length > 0) {
     const cheapest = flights.reduce(
       (best, f) => (priceOrInfinity(f.price) < priceOrInfinity(best.price) ? f : best),
       flights[0],
     );
-    setFlight(flightStableKey(cheapest));
+    flightId = flightStableKey(cheapest);
   }
+  let hotelId: string | null = null;
   const hotels = (latest.hotel_offers ?? []) as ApiHotelOffer[];
   if (hotels.length > 0) {
     const cheapest = hotels.reduce(
       (best, h) => (priceOrInfinity(h.price) < priceOrInfinity(best.price) ? h : best),
       hotels[0],
     );
-    setHotel(hotelStableKey(cheapest));
+    hotelId = hotelStableKey(cheapest);
   }
+  return { flightId, hotelId };
 }
 
 function resolveTripErrorMessage(err: unknown): string {
@@ -426,7 +486,7 @@ function extractFlightDisplayData(flight: ApiFlightOffer) {
     outboundLastSegment,
     airlineName: firstSegment?.carrier_code
       ? getAirlineName(firstSegment.carrier_code)
-      : (flight.airline_name ?? "Unknown"),
+      : (flight.airline_name ?? getAirlineName(flight.airline_code) ?? "Unknown"),
     outboundDepTime: (() => {
       const t = firstSegment?.departure_time ?? flight.departure_time;
       return t ? formatFlightTime(t) : null;
@@ -488,20 +548,122 @@ function SortHeader({ label, sortKey, activeKey, direction, align, onSort }: Sor
   );
 }
 
+/** Secondary carrier code for the layered AirlineChip when a flight is multi-carrier. */
+function secondaryCarrierCode(flight: ApiFlightOffer): string | null {
+  if (multiCarrierSubtitle(flight) === null) return null;
+  const segments = (flight.itineraries ?? []).flatMap((it) => it.segments ?? []);
+  const primary = segments[0]?.carrier_code ?? null;
+  for (const s of segments) {
+    if (s.carrier_code && s.carrier_code !== primary) return s.carrier_code;
+  }
+  return null;
+}
+
+function FlightRow({
+  flight,
+  isSelected,
+  isExpanded,
+  onSelect,
+}: {
+  flight: ApiFlightOffer;
+  isSelected: boolean;
+  isExpanded: boolean;
+  onSelect: (stableKey: string) => void;
+}) {
+  const stableKey = flightStableKey(flight);
+  const displayData = extractFlightDisplayData(flight);
+  const {
+    airlineName,
+    outboundDepTime,
+    outboundArrTime,
+    returnDepTime,
+    returnArrTime,
+    returnFirstSegment,
+    outbound,
+    returnItinerary,
+  } = displayData;
+
+  const outboundTimes = formatTimeRange(outboundDepTime, outboundArrTime);
+  const returnTimes = formatTimeRange(returnDepTime, returnArrTime);
+  const badge = stopsBadge(flight);
+  const subtitle = multiCarrierSubtitle(flight);
+  const secondary = secondaryCarrierCode(flight);
+  const primaryCode = outbound?.segments?.[0]?.carrier_code ?? flight.airline_code;
+
+  return (
+    <div
+      className={`${styles.flightCardExpandable} ${isSelected ? styles.flightCardBest : ""} ${subtitle ? styles.flightCardMulti : ""}`}
+    >
+      {/* Collapsed header — the whole row is one radio control that both selects
+          the offer and toggles its expanded itinerary. */}
+      <button
+        type="button"
+        role="radio"
+        aria-checked={isSelected}
+        aria-expanded={isExpanded}
+        className={styles.cardHeader}
+        onClick={() => onSelect(stableKey)}
+      >
+        <div className={`${styles.cardHeaderRow} ${styles.cardHeaderRowMain}`}>
+          <span className={styles.flightRadio} aria-hidden="true">
+            <span className={`${styles.radioOuter} ${isSelected ? styles.radioSelected : ""}`}>
+              {isSelected && <span className={styles.radioInner} />}
+            </span>
+          </span>
+          <span className={styles.headerAirlineCell}>
+            <AirlineChip carrierCode={primaryCode} secondaryCode={secondary} />
+            <span className={styles.headerAirlineText}>
+              <span className={styles.headerAirline}>{airlineName}</span>
+              {subtitle && <span className={styles.headerSubtitle}>{subtitle}</span>}
+            </span>
+          </span>
+          <span className={styles.headerTimes}>{outboundTimes}</span>
+          <Badge variant={badge.tone === "success" ? "nonstop" : "stop"} className={styles.stopsBadge}>
+            {badge.label}
+          </Badge>
+          <span className={`${styles.cardPrice} ${isSelected ? styles.cardPriceSelected : ""}`}>
+            {formatPrice(flight.price)}
+          </span>
+          <ChevronDown className={`${styles.chevron} ${isExpanded ? styles.chevronUp : ""}`} />
+        </div>
+        {returnFirstSegment && (
+          <div className={`${styles.cardHeaderRowMain} ${styles.cardHeaderRowReturn}`}>
+            <span />
+            <span className={styles.headerReturnLabel}>Return</span>
+            <span className={styles.headerTimes}>{returnTimes}</span>
+            <span />
+            <span />
+            <span />
+          </div>
+        )}
+      </button>
+
+      {isExpanded && (
+        <div className={styles.cardContent}>
+          {outbound && <ItinerarySection itinerary={outbound} />}
+          {returnItinerary && (
+            <>
+              <div className={styles.itineraryDivider} />
+              <ItinerarySection itinerary={returnItinerary} isReturn />
+            </>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
 function FlightsList({
   flights,
-  departDate,
-  returnDate,
   selectedFlightKey,
+  expandedFlightKey,
   onSelectFlight,
 }: {
   flights: ApiFlightOffer[];
-  departDate: string;
-  returnDate?: string | null;
   selectedFlightKey: string | null;
+  expandedFlightKey: string | null;
   onSelectFlight: (stableKey: string) => void;
 }) {
-  const [expandedCards, setExpandedCards] = useState<Set<string>>(new Set());
   const [sortKey, setSortKey] = useState<FlightSortKey>("price");
   const [sortDir, setSortDir] = useState<SortDir>("asc");
 
@@ -550,18 +712,6 @@ function FlightsList({
     );
   }
 
-  const toggleCard = (id: string) => {
-    setExpandedCards(prev => {
-      const next = new Set(prev);
-      if (next.has(id)) {
-        next.delete(id);
-      } else {
-        next.add(id);
-      }
-      return next;
-    });
-  };
-
   return (
     <div className={styles.flightsList}>
       <div className={styles.flightsHeaderRow}>
@@ -574,89 +724,14 @@ function FlightsList({
       </div>
       {sortedFlights.map((flight) => {
         const stableKey = flightStableKey(flight);
-        const isSelected = stableKey === selectedFlightKey;
-        const isExpanded = expandedCards.has(flight.id);
-        const isDirect = flight.stops === 0;
-        const displayData = extractFlightDisplayData(flight);
-        const {
-          airlineName,
-          outboundDepTime,
-          outboundArrTime,
-          returnDepTime,
-          returnArrTime,
-          returnFirstSegment,
-          outbound,
-          returnItinerary,
-        } = displayData;
-
-        const outboundTimes = formatTimeRange(outboundDepTime, outboundArrTime);
-        const returnTimes = formatTimeRange(returnDepTime, returnArrTime);
-        const stops = flight.stops ?? 0;
-        const stopsLabel = isDirect ? "Direct" : `${stops} ${stops === 1 ? "stop" : "stops"}`;
-
         return (
-          <div
+          <FlightRow
             key={flight.id}
-            className={`${styles.flightCardExpandable} ${isSelected ? styles.flightCardBest : ""}`}
-          >
-            {/* Collapsed Header - Two-row layout showing outbound + return */}
-            <button
-              type="button"
-              className={styles.cardHeader}
-              onClick={() => toggleCard(flight.id)}
-              aria-expanded={isExpanded}
-            >
-              {/* Row 1: Outbound */}
-              <div className={`${styles.cardHeaderRow} ${styles.cardHeaderRowMain}`}>
-                <div
-                  className={styles.flightRadio}
-                  onClick={(e) => { e.stopPropagation(); onSelectFlight(stableKey); }}
-                  onKeyDown={() => {}}
-                  role="radio"
-                  aria-checked={isSelected}
-                  tabIndex={-1}
-                >
-                  <div className={`${styles.radioOuter} ${isSelected ? styles.radioSelected : ""}`}>
-                    {isSelected && <div className={styles.radioInner} />}
-                  </div>
-                </div>
-                <span className={styles.headerAirline}>{airlineName}</span>
-                <span className={styles.headerTimes}>{outboundTimes}</span>
-                <span className={`${styles.directBadge} ${isDirect ? styles.directBadgeGreen : ""}`}>
-                  <Plane className="h-3 w-3" />
-                  {stopsLabel}
-                </span>
-                <span className={styles.cardPrice}>
-                  {formatPrice(flight.price)}
-                </span>
-                <ChevronDown className={`${styles.chevron} ${isExpanded ? styles.chevronUp : ""}`} />
-              </div>
-              {/* Row 2: Return (if round trip) — same grid as Row 1 */}
-              {returnFirstSegment && (
-                <div className={`${styles.cardHeaderRowMain} ${styles.cardHeaderRowReturn}`}>
-                  <span />
-                  <span className={styles.headerReturnLabel}>Return</span>
-                  <span className={styles.headerTimes}>{returnTimes}</span>
-                  <span />
-                  <span />
-                  <span />
-                </div>
-              )}
-            </button>
-
-            {/* Expanded Content */}
-            {isExpanded && (
-              <div className={styles.cardContent}>
-                {outbound && <ItinerarySection itinerary={outbound} />}
-                {returnItinerary && (
-                  <>
-                    <div className={styles.itineraryDivider} />
-                    <ItinerarySection itinerary={returnItinerary} isReturn />
-                  </>
-                )}
-              </div>
-            )}
-          </div>
+            flight={flight}
+            isSelected={stableKey === selectedFlightKey}
+            isExpanded={stableKey === expandedFlightKey}
+            onSelect={onSelectFlight}
+          />
         );
       })}
     </div>
@@ -692,16 +767,17 @@ function HotelsList({
           <button
             key={hotel.id}
             type="button"
+            role="radio"
+            aria-checked={isSelected}
             className={`${styles.hotelCardCompact} ${isSelected ? styles.hotelSelected : ""}`}
             onClick={() => onSelectHotel(stableKey)}
           >
-            <div className={styles.hotelRadioCompact}>
-              <div
-                className={`${styles.radioOuter} ${isSelected ? styles.radioSelected : ""}`}
-              >
-                {isSelected && <div className={styles.radioInner} />}
-              </div>
-            </div>
+            <span className={styles.hotelRadioCompact} aria-hidden="true">
+              <span className={`${styles.radioOuter} ${isSelected ? styles.radioSelected : ""}`}>
+                {isSelected && <span className={styles.radioInner} />}
+              </span>
+            </span>
+            <HotelPhoto alt={hotel.name} />
             <span className={styles.hotelNameCompact} title={hotel.name}>
               {hotel.name}
               {hotel.rating && (
@@ -711,7 +787,7 @@ function HotelsList({
                 </span>
               )}
             </span>
-            <span className={styles.hotelPriceCompact}>
+            <span className={`${styles.hotelPriceCompact} ${isSelected ? styles.hotelPriceSelected : ""}`}>
               {nights > 0 ? (
                 <>
                   <span className={styles.hotelPerNight}>{formatPrice((parsePrice(hotel.price) ?? 0) / nights)} / night</span>
@@ -794,8 +870,7 @@ export default function TripDetailPage({
   const [isUpdatingStatus, setIsUpdatingStatus] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
   const [isRefreshing, setIsRefreshing] = useState(false);
-  const [selectedHotelKey, setSelectedHotelKey] = useState<string | null>(null);
-  const [selectedFlightKey, setSelectedFlightKey] = useState<string | null>(null);
+  const [selection, dispatchSelection] = useReducer(selectionReducer, INITIAL_SELECTION);
   const [offersTab, setOffersTab] = useState<"flights" | "hotels">("flights");
 
   const fetchTripDetails = useCallback(async (showLoading = true) => {
@@ -807,7 +882,8 @@ export default function TripDetailPage({
       const response = await api.trips.getDetails(tripId);
       setTrip(response.data.trip);
       setPriceHistory(response.data.price_history);
-      preselectCheapest(response.data.price_history[0], setSelectedFlightKey, setSelectedHotelKey);
+      const { flightId, hotelId } = cheapestSelection(response.data.price_history[0]);
+      dispatchSelection({ type: "preselect", flightId, hotelId });
     } catch (err) {
       setError(resolveTripErrorMessage(err));
     } finally {
@@ -981,6 +1057,8 @@ export default function TripDetailPage({
   };
 
   // Derive effective prices from selections (fall back to aggregate minimum)
+  const selectedHotelKey = selection.selectedHotelId;
+  const selectedFlightKey = selection.selectedFlightId;
   const selectedHotel = selectedHotelKey
     ? latestOffers.hotels.find((h) => hotelStableKey(h) === selectedHotelKey)
     : null;
@@ -1010,7 +1088,7 @@ export default function TripDetailPage({
   return (
     <div className={styles.containerCompact}>
       {/* Header */}
-      <div className={styles.header}>
+      <div className={`${styles.header} ${styles.stickyRegion}`}>
         <div className={styles.headerRow1}>
           <Button
             variant="ghost"
@@ -1121,8 +1199,8 @@ export default function TripDetailPage({
               </span>
             </div>
             <span className={styles.priceEquals}>=</span>
-            <div className={styles.priceTotal}>
-              <span className={styles.priceTotalValue}>
+            <div className={`${styles.priceTotal} ${styles.auroraTotalCard}`}>
+              <span className={styles.priceTotalValue} data-testid="trip-total">
                 {formatPrice(effectiveTotalPrice)}
               </span>
               {hasTrend &&
@@ -1136,18 +1214,25 @@ export default function TripDetailPage({
             </div>
           </>
         )}
-        {!hasHotelTracking && hasTrend &&
-          previousTotal !== null &&
-          currentTotal !== previousTotal && (
-            <PriceTrend
-              currentPrice={currentTotal}
-              previousPrice={previousTotal}
-            />
-          )}
+        {!hasHotelTracking && (
+          <div className={`${styles.priceTotal} ${styles.auroraTotalCard}`}>
+            <span className={styles.priceTotalValue} data-testid="trip-total">
+              {formatPrice(effectiveTotalPrice)}
+            </span>
+            {hasTrend &&
+              previousTotal !== null &&
+              currentTotal !== previousTotal && (
+                <PriceTrend
+                  currentPrice={currentTotal}
+                  previousPrice={previousTotal}
+                />
+              )}
+          </div>
+        )}
       </div>
 
       {/* Main Content Grid — chart left, offers right */}
-      <div className={styles.gridCompactFlightsOnly}>
+      <div className={styles.offersGrid}>
         {/* Chart */}
         <Card className={styles.chartCard}>
           <CardContent className={styles.chartCardContent}>
@@ -1206,6 +1291,7 @@ export default function TripDetailPage({
               selectedFlightKey={selectedFlightKey}
               selectedFlightLabel={selectedFlightLabel}
               showHotel={hasHotelTracking}
+              nowTotal={effectiveTotalPrice}
             />
           </CardContent>
         </Card>
@@ -1236,16 +1322,15 @@ export default function TripDetailPage({
                 {offersTab === "flights" ? (
                   <FlightsList
                     flights={latestOffers.flights}
-                    departDate={trip.depart_date}
-                    returnDate={trip.return_date}
                     selectedFlightKey={selectedFlightKey}
-                    onSelectFlight={setSelectedFlightKey}
+                    expandedFlightKey={selection.expandedFlightId}
+                    onSelectFlight={(id) => dispatchSelection({ type: "selectFlight", id })}
                   />
                 ) : (
                   <HotelsList
                     hotels={latestOffers.hotels}
                     selectedHotelKey={selectedHotelKey}
-                    onSelectHotel={setSelectedHotelKey}
+                    onSelectHotel={(id) => dispatchSelection({ type: "selectHotel", id })}
                     nights={nights}
                   />
                 )}
@@ -1258,10 +1343,9 @@ export default function TripDetailPage({
                 </div>
                 <FlightsList
                   flights={latestOffers.flights}
-                  departDate={trip.depart_date}
-                  returnDate={trip.return_date}
                   selectedFlightKey={selectedFlightKey}
-                  onSelectFlight={setSelectedFlightKey}
+                  expandedFlightKey={selection.expandedFlightId}
+                  onSelectFlight={(id) => dispatchSelection({ type: "selectFlight", id })}
                 />
               </>
             )}

--- a/apps/web/src/app/trips/new/page.module.css
+++ b/apps/web/src/app/trips/new/page.module.css
@@ -9,7 +9,7 @@
 
 /* Inner wrapper for max-width centering */
 .container > * {
-  max-width: 800px;
+  max-width: 720px;
   margin-left: auto;
   margin-right: auto;
 }
@@ -29,23 +29,17 @@
   width: 40px;
   height: 40px;
   border-radius: 12px;
-  background: var(--glass-bg);
-  backdrop-filter: blur(8px);
-  border: 1px solid var(--glass-border);
-  color: var(--ink);
+  background: var(--aurora-card);
+  border: 1px solid var(--aurora-hairline);
+  color: var(--aurora-ink);
   transition: all 0.2s ease;
   cursor: pointer;
 }
 
 .backButton:hover {
-  background: rgba(255, 255, 255, 0.9);
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
+  background: var(--aurora-surface-2);
+  box-shadow: var(--aurora-shadow-soft);
   transform: translateY(-1px);
-}
-
-:global(.dark) .backButton:hover {
-  background: rgba(40, 40, 60, 0.9);
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
 }
 
 .headerContent {
@@ -55,14 +49,14 @@
 .title {
   font-family: var(--font-display), "Space Grotesk", sans-serif;
   font-size: 1.75rem;
-  font-weight: 700;
-  color: var(--ink);
+  font-weight: 800;
+  color: var(--aurora-ink);
   margin: 0 0 0.25rem 0;
 }
 
 .subtitle {
   font-size: 0.9rem;
-  color: var(--ink-muted);
+  color: var(--aurora-muted);
   margin: 0;
 }
 
@@ -75,17 +69,12 @@
 }
 
 .section {
-  background: var(--glass-bg);
-  backdrop-filter: blur(8px);
-  border: 1px solid var(--glass-border);
-  border-radius: 1rem;
-  box-shadow: 0 4px 24px rgba(0, 0, 0, 0.06);
+  background: var(--aurora-card);
+  border: 1px solid var(--aurora-hairline);
+  border-radius: var(--aurora-radius-card);
+  box-shadow: var(--aurora-shadow-card);
   overflow: hidden;
   width: 100%;
-}
-
-:global(.dark) .section {
-  box-shadow: 0 4px 24px rgba(0, 0, 0, 0.3);
 }
 
 .sectionHeader {
@@ -93,18 +82,14 @@
   align-items: center;
   justify-content: space-between;
   padding: 1rem 1.5rem;
-  border-bottom: 1px solid hsl(var(--border) / 0.5);
+  border-bottom: 1px solid var(--aurora-hairline);
   cursor: pointer;
   user-select: none;
   transition: background 0.2s ease;
 }
 
 .sectionHeader:hover {
-  background: rgba(255, 255, 255, 0.5);
-}
-
-:global(.dark) .sectionHeader:hover {
-  background: rgba(255, 255, 255, 0.05);
+  background: var(--aurora-surface-2);
 }
 
 .sectionHeaderStatic {
@@ -124,19 +109,19 @@
 .sectionIcon {
   width: 20px;
   height: 20px;
-  color: hsl(var(--primary));
+  color: var(--aurora-violet);
 }
 
 .sectionTitleText {
-  font-weight: 600;
-  color: var(--ink);
-  font-size: 1rem;
+  font-weight: 700;
+  color: var(--aurora-ink);
+  font-size: 15px;
 }
 
 .sectionBadge {
   font-size: 0.75rem;
-  color: var(--ink-muted);
-  background: hsl(var(--muted) / 0.5);
+  color: var(--aurora-body-2);
+  background: var(--aurora-chip);
   padding: 0.25rem 0.5rem;
   border-radius: 0.375rem;
 }
@@ -144,7 +129,7 @@
 .chevron {
   width: 20px;
   height: 20px;
-  color: var(--ink-muted);
+  color: var(--aurora-faint);
   transition: transform 0.2s ease;
 }
 
@@ -192,17 +177,17 @@
 .fieldLabel {
   font-size: 0.8125rem;
   font-weight: 500;
-  color: var(--ink);
+  color: var(--aurora-body-2);
 }
 
 .fieldHint {
   font-size: 0.75rem;
-  color: var(--ink-muted);
+  color: var(--aurora-muted);
 }
 
 .fieldError {
   font-size: 0.75rem;
-  color: hsl(var(--destructive));
+  color: var(--destructive, #dc2626);
 }
 
 /* Toggle row */
@@ -211,7 +196,7 @@
   align-items: center;
   justify-content: space-between;
   padding: 0.75rem 0;
-  border-bottom: 1px solid hsl(var(--border) / 0.3);
+  border-bottom: 1px solid var(--aurora-hairline);
 }
 
 .toggleRow:last-child {
@@ -227,12 +212,12 @@
 .toggleTitle {
   font-size: 0.875rem;
   font-weight: 500;
-  color: var(--ink);
+  color: var(--aurora-ink);
 }
 
 .toggleDescription {
   font-size: 0.75rem;
-  color: var(--ink-muted);
+  color: var(--aurora-muted);
 }
 
 /* Tag input */
@@ -242,21 +227,16 @@
   gap: 0.5rem;
   padding: 0.5rem;
   min-height: 42px;
-  border: 1px solid hsl(var(--border) / 0.6);
+  border: 1px solid var(--aurora-hairline-2);
   border-radius: 0.75rem;
-  background: var(--glass-bg);
-  backdrop-filter: blur(8px);
+  background: var(--aurora-surface);
 }
 
 .tagInput:focus-within {
   outline: none;
-  box-shadow: 0 0 0 2px hsl(var(--ring));
-  border-color: hsl(var(--border));
-  background: rgba(255, 255, 255, 0.8);
-}
-
-:global(.dark) .tagInput:focus-within {
-  background: rgba(40, 40, 60, 0.9);
+  box-shadow: 0 0 0 2px var(--aurora-selected-border);
+  border-color: var(--aurora-selected-border);
+  background: var(--aurora-card);
 }
 
 .tag {
@@ -264,8 +244,8 @@
   align-items: center;
   gap: 0.25rem;
   padding: 0.25rem 0.5rem;
-  background: hsl(var(--primary) / 0.1);
-  color: hsl(var(--primary));
+  background: var(--aurora-chip);
+  color: var(--aurora-violet-deep);
   border-radius: 0.375rem;
   font-size: 0.8125rem;
   font-weight: 500;
@@ -283,7 +263,7 @@
 }
 
 .tagRemove:hover {
-  background: hsl(var(--primary) / 0.2);
+  background: var(--aurora-selected-border);
 }
 
 .tagInputField {
@@ -316,7 +296,7 @@
   transform: translateY(-50%);
   width: 18px;
   height: 18px;
-  color: var(--ink-muted);
+  color: var(--aurora-muted);
   pointer-events: none;
 }
 
@@ -336,7 +316,7 @@
   top: 50%;
   transform: translateY(-50%);
   font-size: 0.875rem;
-  color: var(--ink-muted);
+  color: var(--aurora-muted);
   pointer-events: none;
 }
 

--- a/apps/web/src/app/trips/page.module.css
+++ b/apps/web/src/app/trips/page.module.css
@@ -15,7 +15,7 @@
   justify-content: space-between;
   align-items: center;
   padding-bottom: 0.5rem;
-  border-bottom: 1px solid hsl(var(--border));
+  border-bottom: 1px solid var(--aurora-hairline);
   margin-bottom: 0.5rem;
   flex-shrink: 0;
 }
@@ -29,13 +29,13 @@
 .brandIcon {
   width: 32px;
   height: 32px;
-  background: linear-gradient(135deg, hsl(262 83% 58%) 0%, hsl(340 75% 55%) 100%);
-  border-radius: 8px;
+  background: var(--aurora-grad-primary);
+  border-radius: 11px;
   display: flex;
   align-items: center;
   justify-content: center;
   color: white;
-  box-shadow: 0 2px 8px rgba(124, 58, 237, 0.25);
+  box-shadow: var(--aurora-shadow-btn);
 }
 
 .brandIcon svg {
@@ -83,7 +83,7 @@
   width: 32px;
   height: 32px;
   border-radius: 50%;
-  background: linear-gradient(135deg, hsl(262 83% 65%) 0%, hsl(262 83% 50%) 100%);
+  background: var(--aurora-grad-primary);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -143,8 +143,9 @@
 .title {
   font-family: var(--font-display), "Space Grotesk", sans-serif;
   font-size: 1.75rem;
-  font-weight: 700;
-  color: var(--ink);
+  font-weight: 800;
+  letter-spacing: -0.02em;
+  color: var(--aurora-ink);
   margin: 0;
 }
 
@@ -166,7 +167,7 @@
 
 @media (min-width: 1024px) {
   .columns {
-    grid-template-columns: 1fr 320px;
+    grid-template-columns: 1fr 360px;
     grid-template-rows: 1fr;
   }
 
@@ -177,7 +178,7 @@
 
 @media (min-width: 1280px) {
   .columns {
-    grid-template-columns: 1fr 380px;
+    grid-template-columns: 1fr 360px;
   }
 
   .columns.chatCollapsed {
@@ -187,10 +188,10 @@
 
 /* Trip table panel */
 .tablePanel {
-  background: var(--glass-bg);
-  border: 1px solid var(--glass-border);
-  border-radius: var(--radius);
-  box-shadow: var(--shadow);
+  background: var(--aurora-card);
+  border: 1px solid var(--aurora-hairline);
+  border-radius: var(--aurora-radius-card);
+  box-shadow: var(--aurora-shadow-card);
   overflow: hidden;
   display: flex;
   flex-direction: column;
@@ -204,10 +205,10 @@
 
 /* Chat panel */
 .chatPanel {
-  background: var(--glass-bg);
-  border: 1px solid var(--glass-border);
-  border-radius: var(--radius);
-  box-shadow: var(--shadow);
+  background: var(--aurora-card);
+  border: 1px solid var(--aurora-hairline);
+  border-radius: var(--aurora-radius-card);
+  box-shadow: var(--aurora-shadow-card);
   display: flex;
   flex-direction: column;
   min-height: 300px;
@@ -285,10 +286,11 @@
 }
 
 .tripTable th {
-  background: hsl(var(--background));
-  font-size: 0.75rem;
+  background: var(--aurora-card);
+  color: var(--aurora-muted);
+  font-size: 11px;
   text-transform: uppercase;
-  letter-spacing: 0.05em;
+  letter-spacing: 0.06em;
   white-space: nowrap;
 }
 
@@ -298,6 +300,10 @@
 
 .tripTable td {
   white-space: nowrap;
+}
+
+.tripTable tbody tr:first-child {
+  background: #fbfaff;
 }
 
 .clickableRow {
@@ -342,8 +348,87 @@
 }
 
 .priceTotal {
-  font-weight: 600;
-  color: var(--ink);
+  font-weight: 800;
+  color: var(--aurora-violet);
+}
+
+/* Stacked card list (half-width / narrow viewports, <= 820px) */
+.tripCards {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  padding: 0.75rem;
+  overflow: auto;
+  flex: 1;
+}
+
+.tripCard {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding: 0.875rem 1rem;
+  background: var(--aurora-card);
+  border: 1px solid var(--aurora-hairline);
+  border-radius: var(--aurora-radius-card);
+  box-shadow: var(--aurora-shadow-card);
+  color: inherit;
+  text-decoration: none;
+  transition: border-color 0.15s ease;
+}
+
+.tripCard:hover {
+  border-color: var(--aurora-hairline-2);
+}
+
+.tripCardHead {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.tripCardName {
+  font-weight: 700;
+  color: var(--aurora-ink);
+}
+
+.tripCardMeta {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.8125rem;
+  color: var(--aurora-muted);
+}
+
+.tripCardStats {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 0.5rem;
+  margin-top: 0.25rem;
+}
+
+.tripCardStat {
+  display: flex;
+  flex-direction: column;
+  gap: 0.125rem;
+}
+
+.tripCardStatLabel {
+  font-size: 10px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--aurora-muted);
+}
+
+/* Pinned table footer */
+.tableFooter {
+  display: flex;
+  justify-content: space-between;
+  padding: 10px 16px;
+  border-top: 1px solid var(--aurora-hairline);
+  font-size: 12px;
+  color: var(--aurora-muted);
+  flex-shrink: 0;
 }
 
 /* Date display */

--- a/apps/web/src/app/trips/page.tsx
+++ b/apps/web/src/app/trips/page.tsx
@@ -89,19 +89,38 @@ function mapApiTripToDisplayTrip(trip: TripResponse): DisplayTrip {
   };
 }
 
+/**
+ * Tracks whether a CSS media query currently matches.
+ * SSR/jsdom-safe: returns `false` when `window.matchMedia` is unavailable, so the
+ * default (desktop) table view renders on the server and in tests.
+ */
+function useMediaQuery(query: string): boolean {
+  const [matches, setMatches] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
+      return;
+    }
+    const mql = window.matchMedia(query);
+    const onChange = () => setMatches(mql.matches);
+    onChange();
+    mql.addEventListener("change", onChange);
+    return () => mql.removeEventListener("change", onChange);
+  }, [query]);
+
+  return matches;
+}
+
 function getStatusVariant(
   status: DisplayStatus
-): "default" | "secondary" | "outline" {
+): "active" | "paused" | "stop" {
   switch (status) {
     case "ACTIVE":
-      return "default";
-    case "PAUSED":
-    case "EXPIRED":
-      return "secondary";
+      return "active";
     case "ERROR":
-      return "outline";
+      return "stop";
     default:
-      return "outline";
+      return "paused"; // PAUSED, EXPIRED
   }
 }
 
@@ -317,6 +336,9 @@ export default function DashboardPage() {
 
   // Chat panel state with localStorage persistence
   const { isExpanded: isChatExpanded, setExpanded: setChatExpanded, isHydrated } = useChatExpanded(true);
+
+  // Below 820px the table is swapped for a stacked card list.
+  const isCompact = useMediaQuery("(max-width: 820px)");
 
   // Handle SSE price updates - update trip table when new prices arrive
   const handlePriceUpdate = useCallback((update: PriceUpdateEvent) => {
@@ -691,6 +713,58 @@ export default function DashboardPage() {
             </div>
           ) : trips.length === 0 ? (
             <EmptyState />
+          ) : isCompact ? (
+            <div className={styles.tripCards}>
+              {trips.map((trip) => (
+                <Link
+                  key={trip.id}
+                  href={`/trips/${trip.id}`}
+                  className={styles.tripCard}
+                >
+                  <div className={styles.tripCardHead}>
+                    <span className={styles.tripCardName}>{trip.name}</span>
+                    <Badge variant={getStatusVariant(trip.status)}>
+                      {trip.status}
+                    </Badge>
+                  </div>
+                  <div className={styles.tripCardMeta}>
+                    <span className={styles.route}>
+                      <span>{trip.origin_airport}</span>
+                      <span className={styles.routeArrow}>
+                        {trip.is_round_trip ? "↔" : "→"}
+                      </span>
+                      <span>{trip.destination_code}</span>
+                    </span>
+                    <span aria-hidden="true">·</span>
+                    <span>
+                      {formatShortDate(trip.depart_date)}
+                      {trip.return_date &&
+                        ` – ${formatShortDate(trip.return_date)}`}
+                    </span>
+                  </div>
+                  <div className={styles.tripCardStats}>
+                    <div className={styles.tripCardStat}>
+                      <span className={styles.tripCardStatLabel}>Flight</span>
+                      <span className={styles.price}>
+                        {formatPrice(trip.flight_price)}
+                      </span>
+                    </div>
+                    <div className={styles.tripCardStat}>
+                      <span className={styles.tripCardStatLabel}>Hotel</span>
+                      <span className={styles.price}>
+                        {formatPrice(trip.hotel_price)}
+                      </span>
+                    </div>
+                    <div className={styles.tripCardStat}>
+                      <span className={styles.tripCardStatLabel}>Total</span>
+                      <span className={`${styles.price} ${styles.priceTotal}`}>
+                        {formatPrice(trip.total_price)}
+                      </span>
+                    </div>
+                  </div>
+                </Link>
+              ))}
+            </div>
           ) : (
             <div className={styles.tableWrapper}>
               <Table className={styles.tripTable} noWrapper>
@@ -771,6 +845,15 @@ export default function DashboardPage() {
                   ))}
                 </TableBody>
               </Table>
+            </div>
+          )}
+          {!error && !isLoading && trips.length > 0 && (
+            <div className={styles.tableFooter}>
+              <span>
+                Showing {trips.length} of {trips.length} trip
+                {trips.length === 1 ? "" : "s"}
+              </span>
+              <span>Prices refresh daily at 6:00 AM</span>
             </div>
           )}
         </div>

--- a/apps/web/src/app/trips/settings/page.tsx
+++ b/apps/web/src/app/trips/settings/page.tsx
@@ -63,7 +63,7 @@ export default function SettingsPage() {
         Back
       </Button>
 
-      <h1 className="mb-6 text-2xl font-semibold">Settings</h1>
+      <h1 className="mb-6 text-2xl font-extrabold">Settings</h1>
 
       <Card>
         <CardHeader>
@@ -86,6 +86,20 @@ export default function SettingsPage() {
               disabled={saving}
               onCheckedChange={handleToggleEmail}
               aria-label="Email notifications"
+            />
+          </div>
+          <div className="mt-4 flex items-center justify-between gap-4 border-t border-[var(--aurora-hairline)] pt-4">
+            <div className="space-y-0.5">
+              <Label htmlFor="sms-notifications">SMS alerts</Label>
+              <p className="text-sm text-muted-foreground">
+                Instant text on a major price drop.
+              </p>
+            </div>
+            <Switch
+              id="sms-notifications"
+              checked={false}
+              disabled
+              aria-label="SMS alerts"
             />
           </div>
         </CardContent>

--- a/apps/web/src/components/aurora/airline-chip.module.css
+++ b/apps/web/src/components/aurora/airline-chip.module.css
@@ -1,0 +1,7 @@
+.stack { display: inline-flex; align-items: center; }
+.chip {
+  display: inline-flex; align-items: center; justify-content: center;
+  width: 28px; height: 28px; border-radius: 8px;
+  color: #fff; font-weight: 800; font-size: 11px; letter-spacing: .02em;
+}
+.behind { margin-right: -10px; box-shadow: 0 0 0 2px #fff; }

--- a/apps/web/src/components/aurora/airline-chip.tsx
+++ b/apps/web/src/components/aurora/airline-chip.tsx
@@ -1,0 +1,27 @@
+import { airlineChip } from "@/lib/aurora";
+import styles from "./airline-chip.module.css";
+
+export function AirlineChip({
+  carrierCode,
+  secondaryCode,
+}: {
+  carrierCode: string | null | undefined;
+  secondaryCode?: string | null;
+}) {
+  const primary = airlineChip(carrierCode);
+  return (
+    <span className={styles.stack}>
+      {secondaryCode != null && (
+        <span
+          className={`${styles.chip} ${styles.behind}`}
+          style={{ backgroundImage: airlineChip(secondaryCode).gradient }}
+        >
+          {airlineChip(secondaryCode).initials}
+        </span>
+      )}
+      <span className={styles.chip} style={{ backgroundImage: primary.gradient }}>
+        {primary.initials}
+      </span>
+    </span>
+  );
+}

--- a/apps/web/src/components/aurora/hotel-photo.module.css
+++ b/apps/web/src/components/aurora/hotel-photo.module.css
@@ -1,0 +1,7 @@
+.photo { width: 48px; height: 48px; border-radius: 10px; object-fit: cover; }
+.placeholder {
+  display: inline-flex; align-items: center; justify-content: center;
+  width: 48px; height: 48px; border-radius: 10px;
+  background: var(--aurora-surface); color: var(--aurora-violet);
+}
+.placeholderIcon { width: 22px; height: 22px; }

--- a/apps/web/src/components/aurora/hotel-photo.tsx
+++ b/apps/web/src/components/aurora/hotel-photo.tsx
@@ -1,0 +1,20 @@
+import { Hotel } from "lucide-react";
+import styles from "./hotel-photo.module.css";
+
+export function HotelPhoto({
+  src,
+  alt,
+}: {
+  src?: string | null;
+  alt: string;
+}) {
+  if (src) {
+    // eslint-disable-next-line @next/next/no-img-element
+    return <img className={styles.photo} src={src} alt={alt} />;
+  }
+  return (
+    <span className={styles.placeholder} aria-hidden="true">
+      <Hotel className={styles.placeholderIcon} />
+    </span>
+  );
+}

--- a/apps/web/src/components/chat/chat-message.tsx
+++ b/apps/web/src/components/chat/chat-message.tsx
@@ -81,7 +81,7 @@ export function ChatMessage({ message, toolResults = [], pendingUpdateIds, class
               "rounded-2xl px-4 py-2.5",
               isUser
                 ? "bg-primary text-primary-foreground rounded-tr-sm"
-                : "bg-muted dark:bg-white/10 rounded-tl-sm"
+                : "bg-white border border-[var(--aurora-hairline)] dark:bg-white/10 dark:border-white/10 rounded-tl-sm"
             )}
           >
             {message.content ? (

--- a/apps/web/src/components/chat/chat-panel.tsx
+++ b/apps/web/src/components/chat/chat-panel.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useRef, useCallback, useLayoutEffect } from "react";
-import { RefreshCw, X, AlertCircle, Plus } from "lucide-react";
+import { RefreshCw, X, AlertCircle, Plus, Sparkles } from "lucide-react";
 import { cn } from "../../lib/utils";
 import { Button } from "../ui/button";
 import { useChatContext } from "../../lib/chat-provider";
@@ -65,9 +65,20 @@ export function ChatPanel({
       )}
     >
       {/* Header */}
-      <div className="flex items-center justify-between px-4 py-3 border-b border-border/60">
+      <div className="flex items-center justify-between px-4 py-3 border-b border-[var(--aurora-hairline)]">
         <div className="flex items-center gap-2">
-          <h2 className="font-semibold text-sm">Travel Assistant</h2>
+          <span
+            className="aurora-logo flex-shrink-0 w-7 h-7"
+            aria-hidden="true"
+          >
+            <Sparkles className="h-4 w-4" />
+          </span>
+          <div className="flex flex-col leading-tight">
+            <h2 className="font-semibold text-sm">Assistant</h2>
+            <span className="text-[10px] text-muted-foreground">
+              Powered by Groq
+            </span>
+          </div>
           {isLoading && (
             <span className="inline-flex items-center gap-1 text-xs text-muted-foreground">
               <span className="relative flex h-2 w-2">

--- a/apps/web/src/components/chat/tool-call-display.tsx
+++ b/apps/web/src/components/chat/tool-call-display.tsx
@@ -148,7 +148,7 @@ function ToolCallHeader({
   return (
     <div
       className={cn(
-        "w-full flex items-center gap-2 px-3 py-2 text-left",
+        "w-full flex items-center gap-2 px-3 py-2 text-left rounded-full bg-[var(--aurora-surface)] border border-[var(--aurora-hairline)] dark:bg-white/5 dark:border-white/10",
         hasExpandableContent && "hover:bg-muted/50 dark:hover:bg-white/5 transition-colors cursor-pointer"
       )}
       onClick={hasExpandableContent ? onToggle : undefined}

--- a/apps/web/src/components/trip-form/collapsible-section.module.css
+++ b/apps/web/src/components/trip-form/collapsible-section.module.css
@@ -1,15 +1,10 @@
 .section {
-  background: var(--glass-bg);
-  backdrop-filter: blur(8px);
-  border: 1px solid var(--glass-border);
-  border-radius: 1rem;
-  box-shadow: 0 4px 24px rgba(0, 0, 0, 0.06);
+  background: var(--aurora-card);
+  border: 1px solid var(--aurora-hairline);
+  border-radius: var(--aurora-radius-card);
+  box-shadow: var(--aurora-shadow-card);
   overflow: hidden;
   width: 100%;
-}
-
-:global(.dark) .section {
-  box-shadow: 0 4px 24px rgba(0, 0, 0, 0.3);
 }
 
 .sectionHeader {
@@ -17,18 +12,14 @@
   align-items: center;
   justify-content: space-between;
   padding: 1rem 1.5rem;
-  border-bottom: 1px solid hsl(var(--border) / 0.5);
+  border-bottom: 1px solid var(--aurora-hairline);
   cursor: pointer;
   user-select: none;
   transition: background 0.2s ease;
 }
 
 .sectionHeader:hover {
-  background: rgba(255, 255, 255, 0.5);
-}
-
-:global(.dark) .sectionHeader:hover {
-  background: rgba(255, 255, 255, 0.05);
+  background: var(--aurora-surface-2);
 }
 
 .sectionTitle {
@@ -43,19 +34,19 @@
   justify-content: center;
   width: 20px;
   height: 20px;
-  color: hsl(var(--primary));
+  color: var(--aurora-violet);
 }
 
 .sectionTitleText {
-  font-weight: 600;
-  color: var(--ink);
-  font-size: 1rem;
+  font-weight: 700;
+  color: var(--aurora-ink);
+  font-size: 15px;
 }
 
 .sectionBadge {
   font-size: 0.75rem;
-  color: var(--ink-muted);
-  background: hsl(var(--muted) / 0.5);
+  color: var(--aurora-body-2);
+  background: var(--aurora-chip);
   padding: 0.25rem 0.5rem;
   border-radius: 0.375rem;
 }
@@ -63,7 +54,7 @@
 .chevron {
   width: 20px;
   height: 20px;
-  color: var(--ink-muted);
+  color: var(--aurora-faint);
   transition: transform 0.2s ease;
 }
 

--- a/apps/web/src/components/trip-form/flight-prefs-section.module.css
+++ b/apps/web/src/components/trip-form/flight-prefs-section.module.css
@@ -21,12 +21,45 @@
 .fieldLabel {
   font-size: 0.8125rem;
   font-weight: 500;
-  color: var(--ink);
+  color: var(--aurora-body-2);
 }
 
 .fieldHint {
   font-size: 0.75rem;
-  color: var(--ink-muted);
+  color: var(--aurora-muted);
+}
+
+/* Cabin class pill chips */
+.cabinChips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.cabinChip {
+  padding: 0.4375rem 0.875rem;
+  font-size: 0.8125rem;
+  font-weight: 500;
+  color: var(--aurora-body);
+  background: var(--aurora-surface);
+  border: 1px solid var(--aurora-hairline);
+  border-radius: var(--aurora-radius-chip);
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease;
+}
+
+.cabinChip:hover:not(:disabled) {
+  border-color: var(--aurora-selected-border);
+}
+
+.cabinChipSelected {
+  background: var(--aurora-chip);
+  color: var(--aurora-violet-deep);
+  border: 1px solid var(--aurora-selected-border);
+}
+
+.cabinChip:disabled {
+  cursor: not-allowed;
 }
 
 .checkboxRow {

--- a/apps/web/src/components/trip-form/flight-prefs-section.tsx
+++ b/apps/web/src/components/trip-form/flight-prefs-section.tsx
@@ -66,22 +66,23 @@ export function FlightPrefsSection({
         <div className={styles.gridTwo}>
           <div className={styles.field}>
             <Label className={styles.fieldLabel}>Cabin Class</Label>
-            <Select
-              value={cabin}
-              onValueChange={onCabinChange}
-              disabled={disabled}
-            >
-              <SelectTrigger>
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                {CABIN_CLASSES.map((c) => (
-                  <SelectItem key={c.value} value={c.value}>
+            <div className={styles.cabinChips} role="group" aria-label="Cabin Class">
+              {CABIN_CLASSES.map((c) => {
+                const selected = c.value === cabin;
+                return (
+                  <button
+                    key={c.value}
+                    type="button"
+                    className={`${styles.cabinChip} ${selected ? styles.cabinChipSelected : ""}`}
+                    aria-pressed={selected}
+                    disabled={disabled}
+                    onClick={() => onCabinChange(c.value)}
+                  >
                     {c.label}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
+                  </button>
+                );
+              })}
+            </div>
           </div>
           <div className={styles.field}>
             <Label className={styles.fieldLabel}>Stops</Label>

--- a/apps/web/src/components/trip-form/hotel-prefs-section.module.css
+++ b/apps/web/src/components/trip-form/hotel-prefs-section.module.css
@@ -21,7 +21,7 @@
 .fieldLabel {
   font-size: 0.8125rem;
   font-weight: 500;
-  color: var(--ink);
+  color: var(--aurora-body-2);
 }
 
 .checkboxRow {
@@ -54,5 +54,5 @@
 
 .fieldHint {
   font-size: 0.75rem;
-  color: var(--muted-foreground, #6b7280);
+  color: var(--aurora-muted);
 }

--- a/apps/web/src/components/trip-form/notification-section.module.css
+++ b/apps/web/src/components/trip-form/notification-section.module.css
@@ -1,15 +1,10 @@
 .section {
-  background: var(--glass-bg);
-  backdrop-filter: blur(8px);
-  border: 1px solid var(--glass-border);
-  border-radius: 1rem;
-  box-shadow: 0 4px 24px rgba(0, 0, 0, 0.06);
+  background: var(--aurora-card);
+  border: 1px solid var(--aurora-hairline);
+  border-radius: var(--aurora-radius-card);
+  box-shadow: var(--aurora-shadow-card);
   overflow: hidden;
   width: 100%;
-}
-
-:global(.dark) .section {
-  box-shadow: 0 4px 24px rgba(0, 0, 0, 0.3);
 }
 
 .sectionHeader {
@@ -17,7 +12,7 @@
   align-items: center;
   justify-content: space-between;
   padding: 1rem 1.5rem;
-  border-bottom: 1px solid hsl(var(--border) / 0.5);
+  border-bottom: 1px solid var(--aurora-hairline);
   cursor: default;
 }
 
@@ -30,13 +25,13 @@
 .sectionIcon {
   width: 20px;
   height: 20px;
-  color: hsl(var(--primary));
+  color: var(--aurora-violet);
 }
 
 .sectionTitleText {
-  font-weight: 600;
-  color: var(--ink);
-  font-size: 1rem;
+  font-weight: 700;
+  color: var(--aurora-ink);
+  font-size: 15px;
 }
 
 .sectionContent {
@@ -68,12 +63,12 @@
 .fieldLabel {
   font-size: 0.8125rem;
   font-weight: 500;
-  color: var(--ink);
+  color: var(--aurora-body-2);
 }
 
 .fieldError {
   font-size: 0.75rem;
-  color: hsl(var(--destructive));
+  color: var(--destructive, #dc2626);
 }
 
 /* Toggle row */
@@ -82,7 +77,7 @@
   align-items: center;
   justify-content: space-between;
   padding: 0.75rem 0;
-  border-bottom: 1px solid hsl(var(--border) / 0.3);
+  border-bottom: 1px solid var(--aurora-hairline);
 }
 
 .toggleRow:last-child {
@@ -98,12 +93,12 @@
 .toggleTitle {
   font-size: 0.875rem;
   font-weight: 500;
-  color: var(--ink);
+  color: var(--aurora-ink);
 }
 
 .toggleDescription {
   font-size: 0.75rem;
-  color: var(--ink-muted);
+  color: var(--aurora-muted);
 }
 
 /* Currency input */
@@ -117,7 +112,7 @@
   top: 50%;
   transform: translateY(-50%);
   font-size: 0.875rem;
-  color: var(--ink-muted);
+  color: var(--aurora-muted);
   pointer-events: none;
 }
 

--- a/apps/web/src/components/ui/badge.tsx
+++ b/apps/web/src/components/ui/badge.tsx
@@ -12,6 +12,10 @@ const badgeVariants = cva(
         secondary: "bg-secondary text-secondary-foreground",
         destructive: "bg-destructive text-destructive-foreground",
         outline: "text-foreground border-border",
+        active: "aurora-chip-active",
+        paused: "aurora-chip-paused",
+        nonstop: "aurora-chip-nonstop",
+        stop: "aurora-chip-stop",
       },
     },
     defaultVariants: {

--- a/apps/web/src/components/ui/card.tsx
+++ b/apps/web/src/components/ui/card.tsx
@@ -9,7 +9,7 @@ const Card = React.forwardRef<
   <div
     ref={ref}
     className={cn(
-      "rounded-xl border border-border/60 dark:border-white/20 bg-white dark:bg-[rgb(18,18,28)] text-gray-900 dark:text-white shadow",
+      "rounded-[15px] border border-[var(--aurora-hairline)] bg-white text-gray-900 shadow-[0_16px_50px_rgba(60,40,120,0.13)] dark:border-white/20 dark:bg-[rgb(18,18,28)] dark:text-white",
       className
     )}
     {...props}

--- a/apps/web/src/components/ui/tabs.tsx
+++ b/apps/web/src/components/ui/tabs.tsx
@@ -14,7 +14,7 @@ const TabsList = React.forwardRef<
   <TabsPrimitive.List
     ref={ref}
     className={cn(
-      "inline-flex h-11 items-center justify-center rounded-full bg-muted p-1 text-muted-foreground",
+      "inline-flex h-11 items-center justify-center rounded-full bg-[var(--aurora-surface)] p-1 text-muted-foreground",
       className,
     )}
     {...props}
@@ -29,7 +29,7 @@ const TabsTrigger = React.forwardRef<
   <TabsPrimitive.Trigger
     ref={ref}
     className={cn(
-      "inline-flex items-center justify-center whitespace-nowrap rounded-full px-4 py-2 text-sm font-semibold transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow",
+      "inline-flex items-center justify-center whitespace-nowrap rounded-full px-4 py-2 text-sm font-semibold transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 data-[state=active]:bg-white data-[state=active]:text-[var(--aurora-violet-deep)] data-[state=active]:shadow-[0_2px_8px_rgba(60,40,120,0.10)]",
       className,
     )}
     {...props}

--- a/apps/web/src/lib/aurora.ts
+++ b/apps/web/src/lib/aurora.ts
@@ -1,0 +1,75 @@
+import type { ApiFlightOffer, ApiFlightSegment } from "@/lib/api";
+import { getAirlineName, formatDuration } from "@/lib/format";
+
+const CHIP_GRADIENTS: Record<string, string> = {
+  AS: "linear-gradient(135deg,#10617F,#093247)",
+  UA: "linear-gradient(135deg,#2456C9,#13357F)",
+  DL: "linear-gradient(135deg,#C8102E,#7A0A1C)",
+};
+const FALLBACK_GRADIENT = "linear-gradient(135deg,#A78BFA,#7C3AED)";
+
+const AIRPORT_CITIES: Record<string, string> = {
+  DEN: "Denver", SFO: "San Francisco", RDM: "Redmond", LAX: "Los Angeles",
+  JFK: "New York", SEA: "Seattle", ORD: "Chicago", DFW: "Dallas",
+  ATL: "Atlanta", PHX: "Phoenix", SLC: "Salt Lake City",
+};
+
+export function airlineChip(
+  carrierCode: string | null | undefined,
+): { initials: string; gradient: string } {
+  const code = (carrierCode ?? "").toUpperCase();
+  if (CHIP_GRADIENTS[code]) {
+    return { initials: code, gradient: CHIP_GRADIENTS[code] };
+  }
+  const initials = code ? code.slice(0, 2).padEnd(2, code[0] ?? "-") : "--";
+  return { initials, gradient: FALLBACK_GRADIENT };
+}
+
+function allSegments(flight: ApiFlightOffer): ApiFlightSegment[] {
+  return (flight.itineraries ?? []).flatMap((it) => it.segments ?? []);
+}
+
+export function operatingCarriers(flight: ApiFlightOffer): string[] {
+  const seen = new Set<string>();
+  const names: string[] = [];
+  for (const s of allSegments(flight)) {
+    const name = getAirlineName(s.carrier_code);
+    if (name && name !== "—" && !seen.has(name)) {
+      seen.add(name);
+      names.push(name);
+    }
+  }
+  return names;
+}
+
+export function multiCarrierSubtitle(flight: ApiFlightOffer): string | null {
+  const names = operatingCarriers(flight);
+  if (names.length <= 1) return null;
+  return `Operated by ${names.join(" & ")}`;
+}
+
+export function stopsBadge(
+  flight: ApiFlightOffer,
+): { label: string; tone: "success" | "warning" } {
+  const stops = flight.stops ?? 0;
+  if (stops === 0) return { label: "NON-STOP", tone: "success" };
+  const outbound = flight.itineraries?.[0]?.segments ?? [];
+  const via = outbound.length > 1 ? outbound[0]?.arrival_airport ?? null : null;
+  const base = `${stops} STOP${stops > 1 ? "S" : ""}`;
+  return { label: via ? `${base} · ${via}` : base, tone: "warning" };
+}
+
+export function layoverLabel(
+  prevSeg: ApiFlightSegment,
+  seg: ApiFlightSegment,
+): string | null {
+  const arr = prevSeg.arrival_time;
+  const dep = seg.departure_time;
+  if (!arr || !dep) return null;
+  const diffMs = new Date(dep).getTime() - new Date(arr).getTime();
+  if (!Number.isFinite(diffMs) || diffMs <= 0) return null;
+  const dur = formatDuration(Math.round(diffMs / 60000));
+  const code = prevSeg.arrival_airport ?? "—";
+  const city = AIRPORT_CITIES[code.toUpperCase()];
+  return city ? `${dur} layover in ${city} (${code})` : `${dur} layover in ${code}`;
+}


### PR DESCRIPTION
## Summary

Reskins the Next.js web app to the **"Aurora"** hi-fi design across all five routes (Sign in, Dashboard + Assistant, Trip detail, Create trip, Settings) at full-width and at the ~720px single-column reflow. **Visual + interaction refresh only** — no data-model, API, schema, or route changes. Implements plan **P1** (`docs/superpowers/plans/2026-06-23-web-aurora.md`); owns `apps/web/**` only.

- **Design tokens & primitives** — maps the full Aurora palette/radius/shadow token set + reusable utility classes into `globals.css`, extends Manrope to weights 400–800, and adds Aurora variants to the shared `button`/`badge`/`card`/`tabs` primitives.
- **Five routes reskinned** — gradient sign-in hero; dashboard with violet/amber status chips, violet totals, pinned footer, and a ≤820px stacked-card view; the interactive **Trip detail** screen (monogram airline chips, multi-carrier "Operated by…" treatment, amber layover pills, hotel photos with placeholder fallback); cabin-class **pill chips** on Create trip; Email + visual-only SMS toggles on Settings.
- **Verified Trip-detail behavior** — the selection→total→chart recompute reproduces the exact spec totals: Alaska + Riverhouse = **$789**, United (1-stop) + Riverhouse = **$754**, Delta + Eviva = **$680**, with the chart "Now $X" badge mirroring the live total.

All three "tweakable" prototype behaviors (airline monogram chips, hotel photos, multi-carrier subtitle) are **always-on**, driven purely by the real segment/photo data — no feature flags. No "Trip members"/sharing UI anywhere; sign-in stays Google-OAuth-only.

## Visual review (all 5 routes)

Captured with Playwright against a local production build (api stubbed at the network layer with fixtures, since the api image won't build in this sandbox). Light theme unless noted.

**Sign in — before (main) → after (Aurora):**

| Before | After | 720px |
|---|---|---|
| ![](https://github.com/ethanasm/vacation-price-tracker/raw/pr-screenshots/sign-in/before-light-full.png) | ![](https://github.com/ethanasm/vacation-price-tracker/raw/pr-screenshots/sign-in/after-light-full.png) | ![](https://github.com/ethanasm/vacation-price-tracker/raw/pr-screenshots/sign-in/after-light-half.png) |

**Dashboard + Assistant** (violet/amber chips, violet totals, pinned footer, Groq assistant panel) — full + 720px:

| Full | 720px |
|---|---|
| ![](https://github.com/ethanasm/vacation-price-tracker/raw/pr-screenshots/dashboard/light-full.png) | ![](https://github.com/ethanasm/vacation-price-tracker/raw/pr-screenshots/dashboard/light-half.png) |

**Trip detail** — note the preselected United option's overlapping **AS·UA monogram chips + "Operated…" subtitle + amber "1 STOP · DEN"**, Delta/Alaska NON-STOP, the retinted chart with the **"Now $680"** badge, and the violet total card:

| Full | 720px |
|---|---|
| ![](https://github.com/ethanasm/vacation-price-tracker/raw/pr-screenshots/trip-detail/light-full.png) | ![](https://github.com/ethanasm/vacation-price-tracker/raw/pr-screenshots/trip-detail/light-half.png) |

**Create trip** & **Settings:**

| Create trip | Settings |
|---|---|
| ![](https://github.com/ethanasm/vacation-price-tracker/raw/pr-screenshots/create-trip/light-full.png) | ![](https://github.com/ethanasm/vacation-price-tracker/raw/pr-screenshots/settings/light-full.png) |

## Known issue — dark mode (tracked in #34)

This app **auto-forces dark mode 6pm–8am** (`apps/web/src/app/layout.tsx:60-61`). Aurora was scoped as a **light-theme reskin** (plan: "do not touch the `.dark` block"), so the new surfaces are hardcoded light and break at night — on the dashboard the page/top-bar/assistant go dark while the trips panel stays white with near-invisible text and the action buttons render as blank white pills:

![](https://github.com/ethanasm/vacation-price-tracker/raw/pr-screenshots/dashboard/dark-full.png)

**Decision: tracked as a follow-up in #34** — proper `.dark` Aurora overrides will be added there. This PR ships the light theme. The peer review was otherwise approve-with-nits (no P0/P1 logic issues).

## Test plan

- [x] New unit/RTL suites: `aurora-tokens`, `badge-aurora`, `sign-in-aurora`, `dashboard-aurora` (+ compact-viewport card test), `aurora` (helpers), `trip-detail-selection` (verified totals), `settings-aurora`
- [x] Pre-existing trip-detail / sign-in / flight-prefs tests updated to the new structure (intent preserved or strengthened, none weakened or skipped)
- [x] `pnpm verify` green — Nx build/lint/typecheck/test:coverage across all 3 projects; web coverage gate met; Python 96.67%; security audits clean
- [x] Production build compiles all 8 routes
- [x] All 5 routes captured (light, full + 720px) + dark-mode dashboard — see Visual review

## Operator / Deployment Steps

**No operator steps.** No new environment variables, DB migrations, GitHub secrets/variables, or one-time infra/credential provisioning. No lockfile change.