### PR TITLE
fix(ci): run both coverage workflows together for complete Sonar coverage

### DIFF
--- a/.github/workflows/nextjs.yml
+++ b/.github/workflows/nextjs.yml
@@ -1,28 +1,42 @@
 name: Next.js
 
 on:
+  # Union path filter shared with python.yml so ANY code change runs BOTH
+  # coverage workflows. SonarCloud downloads web + python coverage by commit
+  # SHA; if only one workflow ran, the other language's report is missing and
+  # Sonar zero-coverages it (tanking Coverage on New Code). Both-or-neither.
   push:
     branches: [main]
     paths:
       - "apps/web/**"
+      - "apps/api/**"
+      - "apps/worker/**"
+      - "pyproject.toml"
+      - "uv.lock"
+      - "alembic.ini"
       - "package.json"
       - "pnpm-lock.yaml"
       - "nx.json"
       - "tsconfig*.json"
-      - ".github/workflows/nextjs.yml"
       - "sonar-project.properties"
+      - ".github/workflows/nextjs.yml"
+      - ".github/workflows/python.yml"
   pull_request:
     branches: [main]
     paths:
       - "apps/web/**"
+      - "apps/api/**"
+      - "apps/worker/**"
+      - "pyproject.toml"
+      - "uv.lock"
+      - "alembic.ini"
       - "package.json"
       - "pnpm-lock.yaml"
       - "nx.json"
       - "tsconfig*.json"
-      - ".github/workflows/nextjs.yml"
       - "sonar-project.properties"
-
-# Cancel superseded runs on a PR; let main builds finish.
+      - ".github/workflows/nextjs.yml"
+      - ".github/workflows/python.yml"
 concurrency:
   group: nextjs-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -1,9 +1,14 @@
 name: Python
 
 on:
+  # Union path filter shared with python.yml so ANY code change runs BOTH
+  # coverage workflows. SonarCloud downloads web + python coverage by commit
+  # SHA; if only one workflow ran, the other language's report is missing and
+  # Sonar zero-coverages it (tanking Coverage on New Code). Both-or-neither.
   push:
     branches: [main]
     paths:
+      - "apps/web/**"
       - "apps/api/**"
       - "apps/worker/**"
       - "pyproject.toml"
@@ -12,11 +17,14 @@ on:
       - "package.json"
       - "pnpm-lock.yaml"
       - "nx.json"
-      - ".github/workflows/python.yml"
+      - "tsconfig*.json"
       - "sonar-project.properties"
+      - ".github/workflows/nextjs.yml"
+      - ".github/workflows/python.yml"
   pull_request:
     branches: [main]
     paths:
+      - "apps/web/**"
       - "apps/api/**"
       - "apps/worker/**"
       - "pyproject.toml"
@@ -25,9 +33,10 @@ on:
       - "package.json"
       - "pnpm-lock.yaml"
       - "nx.json"
-      - ".github/workflows/python.yml"
+      - "tsconfig*.json"
       - "sonar-project.properties"
-
+      - ".github/workflows/nextjs.yml"
+      - ".github/workflows/python.yml"
 concurrency:
   group: python-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -236,6 +236,14 @@ files. **Heads-up:** a green `sonar:verify` only means coverage will map — a
 security finding (e.g. CWE-117 log injection: never log un-scrubbed client input)
 can still drop the gate. Use `--scan` to be sure.
 
+**CI invariant — both coverage workflows must run together.** The SonarQube
+workflow downloads web *and* python coverage **by commit SHA**; if only one of
+`nextjs.yml`/`python.yml` ran for a commit, the other language's report is absent
+and Sonar zero-coverages it (this is what tanked Coverage on New Code to 16.9%
+then 25.7%). The two workflows therefore share an **identical union `paths`
+filter** so any code change runs **both** (both-or-neither). When editing either
+trigger, keep them in lockstep.
+
 ## Verification Preference
 
 - After code changes, automatically run the most relevant tests/checks without


### PR DESCRIPTION
## Summary

The gate failed **again** on Coverage on New Code (25.7%) — but for a *different, CI-plumbing* reason than #23's model exclusion. I pulled the actual scan log for the failing commit (`b09ba4d`) and it's unambiguous:

```
##[warning]no matching workflow run found with any artifacts?
WARN  No report was found for sonar.python.coverage.reportPaths using pattern apps/api/coverage.xml
WARN  No report was found for sonar.python.coverage.reportPaths using pattern apps/worker/coverage.xml
INFO  Sensor JavaScript/TypeScript Coverage — Analysing [.../apps/web/coverage/lcov.info]   ← web present
INFO  Sensor Zero Coverage Sensor
```

**Root cause:** `sonarqube.yml` downloads web + python coverage **by commit SHA**, but `nextjs.yml` and `python.yml` had *different* path filters. A commit that touches only one app (e.g. the recent api-only merges #24/#26, or a web-touching docs merge) triggers only **one** coverage workflow — so the other language's report is absent for that SHA, and Sonar silently (`if_no_artifact_found: warn`) zero-coverages every file of that language (~165 Python files here). That's the 25.7%. My earlier `models/**` exclusion (#23) was a real fix but orthogonal to this.

## The fix

Give both workflows an **identical union `paths` filter** so any code change runs **both** coverage workflows (both-or-neither). This guarantees both reports exist for every commit Sonar scans — which is exactly what the existing concurrency design (`sonarqube.yml`: "re-scans when the slower one finishes; concurrency cancels the earlier, less-complete scan") already *assumed* but the path filters violated.

- `nextjs.yml` + `python.yml`: shared union filter (`apps/web/**`, `apps/api/**`, `apps/worker/**`, build configs, `sonar-project.properties`, both workflow files).
- Docs-only commits still trigger neither (no scan needed — the prior gate status stands).
- `CLAUDE.md`: documents the both-or-neither invariant so the two triggers stay in lockstep.

## Test plan

- [x] Diagnosis proven from the failing scan log (python reports missing, web present, Zero Coverage Sensor ran).
- [x] Local `pnpm sonar:check` is **clean** on current `main` — confirms it's *not* a zero-coverage'd-file class this time (every runtime source is in a report when both reports are present), isolating the cause to the missing artifact.
- [x] YAML validated; both `on:` blocks now identical.
- [x] **This PR self-verifies:** it edits both workflow files (in the union filter), so opening it runs **both** Next.js and Python coverage → the Sonar scan on this PR gets complete coverage → the gate should show Coverage on New Code recover before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VoGSRWAmfDUbq1gkWSDFPX

---
_Generated by [Claude Code](https://claude.ai/code/session_01VoGSRWAmfDUbq1gkWSDFPX)_