### PR TITLE
fix(web): stop panel shadows hard-clipping at the viewport edge

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -115,6 +115,10 @@
   --aurora-on-chip: var(--aurora-violet-deep);
   --aurora-violet-text: var(--aurora-violet);
   --aurora-row-tint: #FBFAFF;
+  /* Soft, low-reach elevation for large viewport-filling panels — fits inside
+     the small gutter of their clipping container so it is never hard-clipped
+     (unlike the big floating-card shadow). */
+  --aurora-shadow-panel: 0 2px 12px rgba(60, 40, 120, 0.08);
 }
 
 /* Dark mode theme - active from 6pm to 8am */
@@ -625,6 +629,7 @@ button[role="combobox"] svg {
   --aurora-on-chip: #C9B6FF;
   --aurora-violet-text: #A78BFA;
   --aurora-row-tint: #211C30;
+  --aurora-shadow-panel: 0 2px 12px rgba(0, 0, 0, 0.38);
   /* shadows read better as depth, not violet glow, on a dark canvas */
   --aurora-shadow-card: 0 16px 50px rgba(0, 0, 0, .45);
   --aurora-shadow-soft: 0 2px 10px rgba(0, 0, 0, .30);

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -204,7 +204,10 @@ body {
 body {
   font-family: var(--font-body), "Manrope", "Helvetica Neue", sans-serif;
   color: var(--ink);
-  background: hsl(var(--card));
+  /* Continuous Aurora canvas across the whole viewport (was flat white), so
+     card shadows fade into the page tint instead of being clipped against a
+     hard white viewport edge. Dark resolves to the dark canvas. */
+  background: var(--aurora-page);
   height: 100vh;
   display: flex;
   flex-direction: column;

--- a/apps/web/src/app/trips/[tripId]/page.module.css
+++ b/apps/web/src/app/trips/[tripId]/page.module.css
@@ -5,6 +5,9 @@
   gap: 0.5rem;
   height: 100%;
   overflow: hidden;
+  /* Bottom gutter so the panels' soft shadow fully fades before this boundary
+     clips, instead of cutting off hard at the panel's bottom edge. */
+  padding-bottom: 0.75rem;
 }
 
 /* Header wrapper - single row that wraps below 50% viewport width */
@@ -358,6 +361,9 @@
 .chartCard {
   min-height: 0;
   overflow: hidden;
+  /* Override the Card component's heavy floating shadow with the contained
+     panel shadow so it fades fully within the gutter instead of hard-clipping. */
+  box-shadow: var(--aurora-shadow-panel) !important;
 }
 
 .chartCardContent {
@@ -447,6 +453,7 @@
 .listCard {
   min-height: 0;
   overflow: hidden;
+  box-shadow: var(--aurora-shadow-panel) !important;
 }
 
 .listCardContent {

--- a/apps/web/src/app/trips/page.module.css
+++ b/apps/web/src/app/trips/page.module.css
@@ -7,6 +7,9 @@
   min-height: 0;
   height: 100%;
   overflow: hidden;
+  /* Bottom gutter so the panels' soft shadow fades fully within the visible
+     area before this boundary clips, instead of cutting off hard. */
+  padding-bottom: 1rem;
 }
 
 /* Header bar with user info and sign out */
@@ -191,7 +194,7 @@
   background: var(--aurora-card);
   border: 1px solid var(--aurora-hairline);
   border-radius: var(--aurora-radius-card);
-  box-shadow: var(--aurora-shadow-card);
+  box-shadow: var(--aurora-shadow-panel);
   overflow: hidden;
   display: flex;
   flex-direction: column;
@@ -208,7 +211,7 @@
   background: var(--aurora-card);
   border: 1px solid var(--aurora-hairline);
   border-radius: var(--aurora-radius-card);
-  box-shadow: var(--aurora-shadow-card);
+  box-shadow: var(--aurora-shadow-panel);
   display: flex;
   flex-direction: column;
   min-height: 300px;
@@ -370,7 +373,7 @@
   background: var(--aurora-card);
   border: 1px solid var(--aurora-hairline);
   border-radius: var(--aurora-radius-card);
-  box-shadow: var(--aurora-shadow-card);
+  box-shadow: var(--aurora-shadow-panel);
   color: inherit;
   text-decoration: none;
   transition: border-color 0.15s ease;


### PR DESCRIPTION
## Summary

Fixes the harsh shadow/edge artifact around the viewport on the dashboard and trip-detail pages — the soft panel shadow was being **hard-clipped** at the panel's bottom edge (a gradient cut against a flat edge), which read as an ugly seam, especially in the trip-detail empty state.

**Two parts:**
1. **Continuous canvas** — the `<body>` painted flat white (`hsl(var(--card))`) while content panels are also white cards, so they only read via their shadow. Paint the body with `--aurora-page` (the Aurora canvas; dark → `#15121E`) so the tint is continuous to the viewport margin and gives the white panels real separation.
2. **Non-clipping panel shadow** — the viewport-filling panels (dashboard table/chat, trip-detail chart/offers) carried the big floating-card shadow (`0 16px 50px`) but sit flush against `overflow: hidden` boundaries, so the bottom of the shadow was clipped to a hard line. Give those panels a contained, theme-aware `--aurora-shadow-panel` plus a small bottom gutter on the clipping containers, so the shadow fades fully within the visible area. Small floating cards (flight/hotel options, form cards) keep the original card shadow.

> I first tried `overflow: visible` on the shell containers — it gave a perfect continuous shadow but broke the offers-list containment (a long list overflowed onto the footer), so I reverted to the contained-shadow + gutter approach, which keeps internal scrolling intact.

## Visual review (after)

| Trip detail — empty (the reported screen) | Trip detail — many offers (list stays contained) |
|---|---|
| ![](https://github.com/ethanasm/vacation-price-tracker/raw/pr-gradient-shots/after/trip-detail-empty.png) | ![](https://github.com/ethanasm/vacation-price-tracker/raw/pr-gradient-shots/after/trip-detail-offers.png) |

| Dashboard | Trip detail — dark |
|---|---|
| ![](https://github.com/ethanasm/vacation-price-tracker/raw/pr-gradient-shots/after/dashboard.png) | ![](https://github.com/ethanasm/vacation-price-tracker/raw/pr-gradient-shots/after/trip-detail-dark.png) |

Panels now have a soft, symmetric shadow that fades continuously into the canvas (no hard bottom cutoff), the offers list scrolls inside its panel, and light is unchanged elsewhere.

## Test plan

- [x] Web targets pass — `jest` **1016 tests**, `typecheck`, `lint` all green
- [x] Verified at a short viewport (panels reach the bottom) that the panel shadow no longer hard-clips, in light **and** dark
- [x] Regression-checked the offers list with 12 offers — it scrolls inside the panel (no footer overflow)
- [ ] `pnpm verify` — web/api/worker pass; **`mobile:*` (lint/typecheck/test:coverage) fail, but that is pre-existing on `main`** and unrelated to this web-only change (confirmed by reproducing with these changes stashed)

## Operator / Deployment Steps

**No operator steps.** No new env vars, migrations, secrets, or lockfile changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_0111y4ojuv8FqnYgDsmTphDK)_