### PR TITLE
ci: add mobile EAS deploy and Maestro e2e pipelines

### DIFF
--- a/.claude/skills/creating-prs/SKILL.md
+++ b/.claude/skills/creating-prs/SKILL.md
@@ -158,7 +158,7 @@ in step 3) before continuing. Surface anything you're deliberately not fixing
     mcp__github__subscribe_pr_activity { owner: "ethanasm", repo: "vacation-price-tracker", pullNumber: <n> }
 
 Events arrive wrapped in `<github-webhook-activity>` tags. CI for this repo runs
-`nextjs.yml` (web build/lint/test), `python.yml` (api + worker), and
+`web.yml` (web build/lint/test), `server.yml` (api + worker), `mobile.yml` (mobile lint/typecheck/test), and
 `sonarqube.yml`. While CI runs you can move on to other work.
 
 ### 7. React to events

--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,3 @@
+self-hosted-runner:
+  labels:
+    - vpt-prod

--- a/.github/workflows/mobile-deploy.yml
+++ b/.github/workflows/mobile-deploy.yml
@@ -290,7 +290,7 @@ jobs:
           BUMP="$BUMP_INPUT"
 
           # Respect a manual bump in the triggering commit.
-          if git diff HEAD~1 HEAD -- apps/mobile/app.config.ts | grep -E "^[+-][[:space:]]*version: '" >/dev/null; then
+          if git diff HEAD~1 HEAD -- apps/mobile/app.config.ts | grep -E "^[+-][[:space:]]*version: [\"']" >/dev/null; then
             echo "Version line changed in the triggering commit — respecting the manual bump."
             BUMP="none"
           fi

--- a/.github/workflows/mobile-deploy.yml
+++ b/.github/workflows/mobile-deploy.yml
@@ -1,0 +1,465 @@
+name: Mobile Deploy (preview)
+
+# Continuous mobile deployment, with an approval gate on store releases.
+#
+#  - OTA path (ungated): JS-only changes run `eas update --branch preview`,
+#    pushing a fresh JS bundle to the preview channel. Stays fully automatic.
+#  - Release path (gated): changes that need a new native binary (added plugin,
+#    new native dep, new permission, changed assets — detected against the
+#    parent commit) route to the `release` job, which targets the
+#    `mobile-release` GitHub environment. With a required reviewer configured,
+#    the job PAUSES before any side effect (version bump, EAS build, store
+#    submit) until someone approves. Reject / let the window lapse → the run
+#    dies clean: no bump, no mobile-v* tag, no build, no upload. The version
+#    scan is range-based (everything since the last mobile-v* tag), so skipping
+#    a release loses nothing.
+#
+#    ONE-TIME SETUP (the gate is FAIL-OPEN until done): GitHub auto-creates the
+#    `mobile-release` environment with no protection on first run → releases
+#    ship immediately. To arm the gate: Settings → Environments →
+#    mobile-release → check "Required reviewers" → add yourself → Save. See
+#    docs/mobile-cicd.md § "Release approval gate".
+#
+# Versioning is automated on the release path. After approval, before
+# `eas build`, the workflow bumps `version` in apps/mobile/app.config.ts,
+# commits it back to main with [skip ci], and tags `mobile-vX.Y.Z`. Minor vs
+# patch is decided by scanning squash-merge subjects on main since the last
+# `mobile-v*` tag: any `feat:` (or a breaking `!`) → minor, otherwise patch
+# (pre-1.0 the 1.0.0 jump is manual). The OTA path NEVER bumps. A manual bump
+# in the triggering merge is respected. workflow_dispatch `bump` overrides the
+# scan. The bump-back push has to clear main's required-PR rule, and the
+# built-in github-actions app can NOT be on a ruleset bypass list — so the push
+# authenticates as a deploy key (RELEASE_DEPLOY_KEY; recommended) or a
+# bypass-listed PAT (RELEASE_PUSH_TOKEN). [skip ci] in the bump commit
+# suppresses CI, and this deploy only runs off Build-Prod-Images completion /
+# manual dispatch, so the bump can't loop.
+#
+# Approved builds auto-submit to the preview store track on BOTH platforms via
+# `eas submit`: Android → Play internal (PLAY_SERVICE_ACCOUNT_JSON), iOS →
+# TestFlight internal (ASC_API_KEY_* secrets).
+#
+# Required secrets (Settings → Secrets → Actions):
+#  - EXPO_TOKEN — eas-cli access token (drives update + build + submit).
+#  - PLAY_SERVICE_ACCOUNT_JSON — Google service-account key JSON with Play
+#    "Manage testing track releases" on the VPT app.
+#  - ASC_API_KEY_P8 — App Store Connect API .p8 contents.
+#  - ASC_API_KEY_ID — key id of that .p8.
+#  - ASC_API_KEY_ISSUER_ID — issuer id from the ASC Integrations page.
+#  - ASC_APP_ID — numeric Apple ID of the VPT app record.
+#  - RELEASE_DEPLOY_KEY (or RELEASE_PUSH_TOKEN) — for the version-bump pushback.
+# Optional (failure email): RESEND_API_KEY, EMAIL_FROM, ADMIN_EMAILS.
+
+on:
+  workflow_run:
+    workflows: ["Build Prod Images"]
+    types: [completed]
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: "update (OTA JS) or build (new native binary; pauses at the mobile-release gate, then auto-submits to Play internal / TestFlight)"
+        type: choice
+        options:
+          - update
+          - build
+        default: update
+      platform:
+        description: "Platform (only used in build mode)"
+        type: choice
+        options:
+          - ios
+          - android
+          - all
+        default: android
+      bump:
+        description: "Version bump (build mode only): auto scans commits since the last mobile-v* tag; none ships the version already in app.config.ts"
+        type: choice
+        options:
+          - auto
+          - patch
+          - minor
+          - none
+        default: auto
+
+permissions:
+  contents: read
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  plan:
+    name: Decide OTA vs build
+    if: >-
+      ${{ github.event_name == 'workflow_dispatch' ||
+          (github.event.workflow_run.conclusion == 'success' &&
+           github.event.workflow_run.head_branch == 'main' &&
+           github.event.workflow_run.event != 'pull_request') }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    outputs:
+      needs_build: ${{ steps.detect-native.outputs.needs_build }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
+          fetch-depth: 0
+
+      # Native changes can't ship via `eas update` (OTA only swaps the JS
+      # bundle). We watch the paths that flow into the native binary; anything
+      # else under apps/mobile/ (app/, components/, lib/, e2e/, tests) is
+      # OTA-shippable. VPT mobile has no local Expo Modules dir, so the watched
+      # set is package.json + app.config.ts + eas.json + assets/.
+      - name: Detect native changes
+        id: detect-native
+        run: |
+          if git rev-parse HEAD~1 >/dev/null 2>&1; then
+            CHANGED=$(git diff --name-only HEAD~1 HEAD -- \
+              'apps/mobile/package.json' \
+              'apps/mobile/app.config.ts' \
+              'apps/mobile/eas.json' \
+              'apps/mobile/assets/' \
+              || true)
+            if [ -n "$CHANGED" ]; then
+              echo "needs_build=true" >> "$GITHUB_OUTPUT"
+              {
+                echo "### Native-affecting paths changed — routing to the gated release job"
+                echo ""
+                echo '```'
+                echo "$CHANGED"
+                echo '```'
+              } >> "$GITHUB_STEP_SUMMARY"
+            else
+              echo "needs_build=false" >> "$GITHUB_OUTPUT"
+            fi
+          else
+            # No parent commit — fail-safe to a build (skipping a needed binary
+            # ships a broken OTA; an unnecessary build only costs EAS time + a
+            # one-click approval).
+            echo "needs_build=true" >> "$GITHUB_OUTPUT"
+            echo "### HEAD~1 unresolvable — defaulting to build" >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+  ota:
+    name: Push OTA update
+    needs: plan
+    if: >-
+      (github.event_name == 'workflow_run' && needs.plan.outputs.needs_build != 'true')
+      || (github.event_name == 'workflow_dispatch' && inputs.mode == 'update')
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    concurrency:
+      group: mobile-deploy-ota
+      cancel-in-progress: false
+    env:
+      EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9.12.1
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Push OTA update
+        working-directory: apps/mobile
+        env:
+          # `eas update` does NOT read the eas.json build-profile `env` block —
+          # that's build-only. For OTA the vars must be in the shell so Metro
+          # inlines them. KEEP IN SYNC with apps/mobile/eas.json base profile env.
+          EXPO_PUBLIC_API_URL: https://vacation-price-tracker.ethanasm.me
+          EXPO_PUBLIC_GOOGLE_OAUTH_CLIENT_ID_IOS: 222563763412-ba4ejjpfgdvq3pl64hrnf0u09sap919q.apps.googleusercontent.com
+          EXPO_PUBLIC_GOOGLE_OAUTH_CLIENT_ID_ANDROID: 222563763412-9qslaeisquai4hsi930c2bihcj3p34bk.apps.googleusercontent.com
+          EXPO_PUBLIC_GOOGLE_OAUTH_CLIENT_ID_WEB: 222563763412-fuonu9krvmvpvpf4dq4m2ggriu8gv113.apps.googleusercontent.com
+        run: |
+          MSG=$(git -C "$GITHUB_WORKSPACE" log -1 --pretty=%s)
+          pnpm dlx eas-cli update \
+            --branch preview \
+            --message "$MSG" \
+            --non-interactive 2>&1 | tee -a "$GITHUB_WORKSPACE/eas-output.log"
+
+      - name: Email error logs on failure
+        if: failure()
+        env:
+          RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
+          EMAIL_FROM: ${{ secrets.EMAIL_FROM }}
+          ALERT_EMAILS: ${{ secrets.ADMIN_EMAILS }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          COMMIT_SHA: ${{ github.event.workflow_run.head_sha || github.sha }}
+          TRIGGER: ${{ github.event_name }}
+          MODE: update
+        run: bash scripts/mobile-deploy-failure-email.sh
+
+      - name: Summary
+        if: always()
+        run: |
+          {
+            echo "### Mobile deploy (OTA)"
+            echo ""
+            echo "- Trigger: ${{ github.event_name }}"
+            echo "- Mode: update"
+            echo "- Status: ${{ job.status }}"
+            echo "- Channel: preview"
+            echo "- Version: unchanged (OTA)"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  release:
+    name: Build + submit to stores (gated)
+    needs: plan
+    if: >-
+      (github.event_name == 'workflow_dispatch' && inputs.mode == 'build')
+      || (github.event_name == 'workflow_run' && needs.plan.outputs.needs_build == 'true')
+    runs-on: ubuntu-latest
+    # THE RELEASE GATE. With a required reviewer on this environment, the job
+    # waits here — before the bump, the builds, and the submits — until
+    # approved. Without protection rules it's pass-through (fail-open). See
+    # docs/mobile-cicd.md § "Release approval gate".
+    environment: mobile-release
+    concurrency:
+      group: mobile-deploy-release
+      cancel-in-progress: false
+    permissions:
+      contents: write
+    timeout-minutes: 75
+    env:
+      EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
+          # main's ruleset requires PRs, which rejects GITHUB_TOKEN pushes. The
+          # built-in github-actions app can NOT be bypass-listed, so the
+          # bump-back push authenticates with one of these (preference order):
+          #  1. RELEASE_DEPLOY_KEY — deploy key with write; "Deploy keys"
+          #     checked in the ruleset bypass list. Recommended.
+          #  2. RELEASE_PUSH_TOKEN — fine-grained PAT (Contents: read/write)
+          #     from a bypass-listed actor.
+          #  3. GITHUB_TOKEN fallback — can fetch, but the bump push WILL be
+          #     rejected while the required-PR rule has no usable bypass.
+          ssh-key: ${{ secrets.RELEASE_DEPLOY_KEY }}
+          token: ${{ secrets.RELEASE_PUSH_TOKEN || github.token }}
+          fetch-depth: 0
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9.12.1
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      # Runs only after approval. Decides the bump, edits app.config.ts via
+      # scripts/bump-mobile-version.mjs, commits + tags mobile-vX.Y.Z, pushes
+      # back to main. The push happens BEFORE eas build so a binary can never
+      # ship a version git doesn't know about.
+      - name: Bump app version
+        id: bump-version
+        env:
+          BUMP_INPUT: ${{ inputs.bump || 'auto' }}
+        run: |
+          set -euo pipefail
+
+          git fetch origin main
+          if ! git merge-base --is-ancestor HEAD origin/main; then
+            echo "::warning::HEAD is not on main — skipping version bump, building with the version already in app.config.ts."
+            echo "version=$(node scripts/bump-mobile-version.mjs --print)" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          BUMP="$BUMP_INPUT"
+
+          # Respect a manual bump in the triggering commit.
+          if git diff HEAD~1 HEAD -- apps/mobile/app.config.ts | grep -E "^[+-][[:space:]]*version: '" >/dev/null; then
+            echo "Version line changed in the triggering commit — respecting the manual bump."
+            BUMP="none"
+          fi
+
+          LAST_TAG=$(git tag -l 'mobile-v*' --sort=-v:refname | sed -n 1p)
+
+          if [ "$BUMP" = "auto" ]; then
+            RANGE="${LAST_TAG:+${LAST_TAG}..HEAD}"
+            RANGE="${RANGE:-HEAD~1..HEAD}"
+            SUBJECTS=$(git log --format=%s "$RANGE" -- || true)
+            if echo "$SUBJECTS" | grep -E '^[a-z]+(\([^)]*\))?!:' >/dev/null; then
+              BUMP="major"
+            elif echo "$SUBJECTS" | grep -iE '^feat(\([^)]*\))?:' >/dev/null; then
+              BUMP="minor"
+            else
+              BUMP="patch"
+            fi
+            echo "Scanned ${RANGE} → bump type: ${BUMP}"
+          fi
+
+          if [ "$BUMP" = "none" ]; then
+            VERSION=$(node scripts/bump-mobile-version.mjs --print)
+            echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+            echo "### Version: ${VERSION} (no auto-bump)" >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          FLOOR="${LAST_TAG#mobile-v}"
+          NEW=$(node scripts/bump-mobile-version.mjs --type "$BUMP" ${LAST_TAG:+--floor "$FLOOR"})
+          while git rev-parse -q --verify "refs/tags/mobile-v$NEW" >/dev/null; do
+            NEW=$(node scripts/bump-mobile-version.mjs --type patch)
+          done
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -B main
+          git add apps/mobile/app.config.ts
+          git commit -m "chore(release): mobile v${NEW} [skip ci]"
+          git tag "mobile-v${NEW}"
+          for i in 1 2 3; do
+            if git push --atomic origin main "mobile-v${NEW}" 2>&1 | tee /tmp/bump-push.log; then
+              break
+            fi
+            if grep -qiE 'protected branch|GH006|GH013' /tmp/bump-push.log; then
+              echo "::error::main's protection rejected the version-bump push. The built-in github-actions app cannot be added to a ruleset bypass list, so configure one of: (1) recommended — check 'Deploy keys' in the ruleset bypass list, add a write-access deploy key, save its private key as RELEASE_DEPLOY_KEY; (2) a PAT from a bypass-listed actor as RELEASE_PUSH_TOKEN. Details: docs/mobile-cicd.md § Versioning."
+              exit 1
+            fi
+            if [ "$i" = 3 ]; then
+              echo "Could not push the version-bump commit after 3 attempts." >&2
+              exit 1
+            fi
+            git fetch origin main
+            git rebase origin/main
+          done
+
+          echo "version=$NEW" >> "$GITHUB_OUTPUT"
+          echo "### Version: ${NEW} (${BUMP} bump, tagged mobile-v${NEW})" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Build Android AAB (preview-store profile)
+        id: build-android
+        if: >-
+          github.event_name == 'workflow_run'
+          || inputs.platform == 'android' || inputs.platform == 'all'
+        working-directory: apps/mobile
+        run: |
+          pnpm dlx eas-cli build \
+            --profile preview-store \
+            --platform android \
+            --non-interactive \
+            --wait 2>&1 | tee -a "$GITHUB_WORKSPACE/eas-output.log"
+
+      - name: Submit Android AAB to Play internal track
+        if: steps.build-android.outcome == 'success'
+        working-directory: apps/mobile
+        env:
+          PLAY_SA_JSON: ${{ secrets.PLAY_SERVICE_ACCOUNT_JSON }}
+        run: |
+          if [ -z "${PLAY_SA_JSON:-}" ]; then
+            echo "PLAY_SERVICE_ACCOUNT_JSON secret is not set — cannot submit to Play." >&2
+            echo "See workflow header comment for setup." >&2
+            exit 1
+          fi
+          # The submit profile resolves serviceAccountKeyPath relative to
+          # eas.json (working dir is apps/mobile/). Write the secret there.
+          SA="./play-service-account.json"
+          printf '%s' "$PLAY_SA_JSON" > "$SA"
+          chmod 600 "$SA"
+          pnpm dlx eas-cli submit \
+            --profile preview-store \
+            --platform android \
+            --latest \
+            --non-interactive 2>&1 | tee -a "$GITHUB_WORKSPACE/eas-output.log"
+          rm -f "$SA"
+
+      # iOS mirrors Android. Prereq (one-time, interactive): the App Store
+      # distribution cert + provisioning profile must already be in EAS
+      # credentials — run `eas build --profile preview-store --platform ios`
+      # once locally so EAS generates them; CI can't answer the prompts.
+      - name: Build iOS IPA (preview-store profile)
+        id: build-ios
+        if: >-
+          github.event_name == 'workflow_run'
+          || inputs.platform == 'ios' || inputs.platform == 'all'
+        working-directory: apps/mobile
+        run: |
+          pnpm dlx eas-cli build \
+            --profile preview-store \
+            --platform ios \
+            --non-interactive \
+            --wait 2>&1 | tee -a "$GITHUB_WORKSPACE/eas-output.log"
+
+      - name: Submit iOS IPA to TestFlight internal testing
+        if: steps.build-ios.outcome == 'success'
+        working-directory: apps/mobile
+        env:
+          ASC_API_KEY_P8: ${{ secrets.ASC_API_KEY_P8 }}
+          ASC_API_KEY_ID: ${{ secrets.ASC_API_KEY_ID }}
+          ASC_API_KEY_ISSUER_ID: ${{ secrets.ASC_API_KEY_ISSUER_ID }}
+          ASC_APP_ID: ${{ secrets.ASC_APP_ID }}
+        run: |
+          for v in ASC_API_KEY_P8 ASC_API_KEY_ID ASC_API_KEY_ISSUER_ID ASC_APP_ID; do
+            if [ -z "${!v:-}" ]; then
+              echo "$v secret is not set — cannot submit to TestFlight." >&2
+              echo "See workflow header comment for setup." >&2
+              exit 1
+            fi
+          done
+          # ascApiKeyPath resolves relative to eas.json; the key id / issuer id /
+          # app id have no CLI flag and eas.json has no env substitution, so
+          # inject them into the submit profile with jq. The edit lives only on
+          # the ephemeral runner; the .p8 is gitignored so a stray git add can't
+          # commit it.
+          KEY="./asc-api-key.p8"
+          printf '%s' "$ASC_API_KEY_P8" > "$KEY"
+          chmod 600 "$KEY"
+          jq --arg keyId "$ASC_API_KEY_ID" \
+             --arg issuerId "$ASC_API_KEY_ISSUER_ID" \
+             --arg appId "$ASC_APP_ID" \
+             '.submit."preview-store".ios += {ascApiKeyId: $keyId, ascApiKeyIssuerId: $issuerId, ascAppId: $appId}' \
+             eas.json > eas.json.tmp && mv eas.json.tmp eas.json
+          pnpm dlx eas-cli submit \
+            --profile preview-store \
+            --platform ios \
+            --latest \
+            --non-interactive 2>&1 | tee -a "$GITHUB_WORKSPACE/eas-output.log"
+          rm -f "$KEY"
+          git checkout -- eas.json || true
+
+      - name: Email error logs on failure
+        if: failure()
+        env:
+          RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
+          EMAIL_FROM: ${{ secrets.EMAIL_FROM }}
+          ALERT_EMAILS: ${{ secrets.ADMIN_EMAILS }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          COMMIT_SHA: ${{ github.event.workflow_run.head_sha || github.sha }}
+          TRIGGER: ${{ github.event_name }}
+          MODE: build
+        run: bash scripts/mobile-deploy-failure-email.sh
+
+      - name: Summary
+        if: always()
+        run: |
+          {
+            echo "### Mobile deploy (store release)"
+            echo ""
+            echo "- Trigger: ${{ github.event_name }}"
+            echo "- Mode: build"
+            echo "- Status: ${{ job.status }}"
+            echo "- Channel: preview"
+            echo "- Version: ${{ steps.bump-version.outputs.version || 'unknown' }}"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/mobile-deploy.yml
+++ b/.github/workflows/mobile-deploy.yml
@@ -344,6 +344,7 @@ jobs:
             fi
             git fetch origin main
             git rebase origin/main
+            git tag -f "mobile-v${NEW}"
           done
 
           echo "version=$NEW" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/mobile-e2e.yml
+++ b/.github/workflows/mobile-e2e.yml
@@ -1,0 +1,452 @@
+name: Mobile E2E (Maestro, Android)
+
+# Android-only e2e on a self-hosted runner inside the prod box. iOS coverage is
+# manual via `maestro test e2e/flows` on the dev Mac. Android catches ~90% of
+# regressions because the surface (auth gate, navigation, optimistic mutations)
+# is platform-shared in RN.
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'apps/mobile/**'
+      - '.github/workflows/mobile-e2e.yml'
+  pull_request:
+    types: [labeled, synchronize, opened, reopened]
+  schedule:
+    # 09:00 UTC — after nightly jobs settle.
+    - cron: '0 9 * * *'
+  workflow_dispatch: {}
+
+permissions:
+  # contents:write for the failure-publish step that pushes Maestro screenshots
+  # to the pr-screenshots orphan branch.
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: mobile-e2e-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  android-e2e:
+    name: Local Android build + Maestro on self-hosted emulator
+    # PR runs require the `mobile-visual` label so opt-in stays explicit;
+    # non-PR triggers (push/schedule/dispatch) always run. The in-step secret
+    # checks below fail loudly if VPT_E2E_BACKEND_TOKEN / the e2e stack aren't
+    # configured, so no silent-skip repo-variable gate is used.
+    #
+    # One-time runner setup (see docs/mobile-cicd.md):
+    #   1. Bring up the isolated VPT e2e backend stack (project vpt-e2e) on the
+    #      prod box from infra/docker-compose.e2e.yml — the loopback-only API the
+    #      emulator reaches at http://10.0.2.2:8010. One-time operator step.
+    #   2. Optional repo variable ANDROID_SDK_ROOT (default /opt/android-sdk).
+    #   3. Run scripts/setup-runner-android.sh once on the prod box (Android SDK
+    #      + build-tools + NDK, the vpt_e2e AVD, Maestro).
+    if: >-
+      github.event_name != 'pull_request' ||
+      contains(github.event.pull_request.labels.*.name, 'mobile-visual')
+    runs-on: [self-hosted, vpt-prod]
+    timeout-minutes: 60
+    env:
+      ANDROID_SDK_ROOT: ${{ vars.ANDROID_SDK_ROOT || '/opt/android-sdk' }}
+      ANDROID_AVD_NAME: vpt_e2e
+      ANDROID_AVD_HOME: ${{ vars.ANDROID_AVD_HOME || '/home/ethan/.android-avd' }}
+      # Gradle in CI: no daemon, single worker, 2 GB heap — the WSL runner OOMs
+      # at higher caps when the 2 GB AVD + Metro run alongside.
+      GRADLE_OPTS: '-Dorg.gradle.daemon=false -Dorg.gradle.workers.max=1 -Dorg.gradle.parallel=false -Dorg.gradle.jvmargs="-Xmx2g -XX:MaxMetaspaceSize=512m"'
+      # The isolated VPT e2e API, reached from the emulator via the AVD's host
+      # alias. Deterministic for the self-hosted setup, so hardcoded.
+      VPT_E2E_API_URL: http://10.0.2.2:8010
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Diagnose runner
+        shell: bash
+        run: |
+          set -u
+          echo "::group::Runner diagnostics"
+          uname -a
+          free -h || true
+          df -h /
+          df -h "$HOME" || true
+          echo "JAVA: $(java -version 2>&1 | head -1)"
+          if [ -e /dev/kvm ] && [ -r /dev/kvm ] && [ -w /dev/kvm ]; then
+            echo "KVM accessible"
+          else
+            echo "KVM missing or not r/w — emulator falls back to software CPU (slow)"
+          fi
+          echo "ANDROID_SDK_ROOT=$ANDROID_SDK_ROOT"
+          [ -d "$ANDROID_SDK_ROOT" ] && ls -la "$ANDROID_SDK_ROOT" || echo "  SDK root missing — run scripts/setup-runner-android.sh"
+          echo "ANDROID_AVD_HOME=$ANDROID_AVD_HOME"
+          [ -x "$ANDROID_SDK_ROOT/emulator/emulator" ] && "$ANDROID_SDK_ROOT/emulator/emulator" -list-avds || true
+          echo "::endgroup::"
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9.12.1
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Materialize AVD on disk
+        shell: bash
+        env:
+          ANDROID_AVD_SYSTEM_IMAGE: ${{ vars.ANDROID_AVD_SYSTEM_IMAGE || 'system-images;android-34;google_apis;x86_64' }}
+        run: |
+          set -euo pipefail
+          mkdir -p "$ANDROID_AVD_HOME"
+          if [ -d "$ANDROID_AVD_HOME/${ANDROID_AVD_NAME}.avd" ]; then
+            echo "AVD already present at $ANDROID_AVD_HOME/${ANDROID_AVD_NAME}.avd"
+          else
+            SDKMANAGER="$ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager"
+            AVDMANAGER="$ANDROID_SDK_ROOT/cmdline-tools/latest/bin/avdmanager"
+            if [ ! -x "$SDKMANAGER" ] || [ ! -x "$AVDMANAGER" ]; then
+              echo "::error::cmdline-tools missing — run scripts/setup-runner-android.sh on the runner"
+              exit 1
+            fi
+            yes | "$SDKMANAGER" --licenses >/dev/null 2>&1 || true
+            "$SDKMANAGER" --install "$ANDROID_AVD_SYSTEM_IMAGE" >/dev/null
+            echo "no" | "$AVDMANAGER" create avd \
+              --name "$ANDROID_AVD_NAME" \
+              --package "$ANDROID_AVD_SYSTEM_IMAGE" \
+              --device "pixel_6" \
+              --path "$ANDROID_AVD_HOME/${ANDROID_AVD_NAME}.avd" \
+              --force
+            CFG="$ANDROID_AVD_HOME/${ANDROID_AVD_NAME}.avd/config.ini"
+            if [ -f "$CFG" ]; then
+              {
+                echo "hw.ramSize=2048"
+                echo "vm.heapSize=512"
+                echo "disk.dataPartition.size=4096M"
+                echo "hw.gpu.enabled=yes"
+                echo "hw.gpu.mode=swiftshader_indirect"
+              } >> "$CFG"
+            fi
+          fi
+          ls -la "$ANDROID_AVD_HOME"
+
+      - name: Install Maestro CLI
+        shell: bash
+        run: |
+          if ! command -v maestro >/dev/null 2>&1; then
+            curl -fsSL "https://get.maestro.mobile.dev" | bash
+          fi
+          echo "$HOME/.maestro/bin" >> "$GITHUB_PATH"
+
+      - name: Validate Maestro flow YAML
+        working-directory: apps/mobile
+        run: node e2e/scripts/dry-run.mjs e2e/flows
+
+      # Mint the e2e bearer from the isolated VPT e2e backend rather than from
+      # hand-maintained secrets. The e2e API exposes the P5-owned token-mint
+      # endpoint POST /v1/e2e/mint-token (gated on E2E_MODE=1, authenticated via
+      # the X-E2E-Token header = VPT_E2E_BACKEND_TOKEN) that returns a JWT (same
+      # create_access_token path the app uses) for the fixed e2e user. The
+      # mobile client attaches it as Authorization: Bearer — which requires P5's
+      # Bearer-header support in get_current_user. Token is short-lived + masked.
+      #
+      # The vpt-e2e stack (infra/docker-compose.e2e.yml, authored by P4) must be
+      # up on the box, listening on the loopback port the emulator reaches at
+      # http://10.0.2.2:8010. One-time operator bring-up: docs/mobile-cicd.md
+      # § "VPT e2e backend stack".
+      - name: Mint e2e session from the running backend
+        shell: bash
+        env:
+          VPT_E2E_BACKEND_TOKEN: ${{ secrets.VPT_E2E_BACKEND_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [ -z "${VPT_E2E_BACKEND_TOKEN:-}" ]; then
+            echo "::error::VPT_E2E_BACKEND_TOKEN secret is not set — cannot mint an e2e session. See docs/mobile-cicd.md."
+            exit 1
+          fi
+          # The e2e backend is reachable from the runner host on loopback at the
+          # same port the emulator maps to 10.0.2.2 (8010 here).
+          BASE="http://127.0.0.1:8010"
+          # P5 mints a FIXED configured user (e2e@vpt.test) — it ignores any
+          # request body. This EMAIL is only used to build the local USER_JSON
+          # below and must match the user P5 upserts + the e2e sign-in allowlist.
+          EMAIL="e2e@vpt.test"
+          # The e2e-only mint endpoint (P5-owned) returns
+          # { access_token, user: { id, email, ... } }. It exists only when the
+          # e2e backend is started with E2E_MODE=1, and is authenticated with the
+          # X-E2E-Token header (NOT Authorization/Bearer). No request body. See
+          # docs/mobile-cicd.md.
+          RESP=$(curl -sS -X POST "${BASE}/v1/e2e/mint-token" \
+            -H "X-E2E-Token: ${VPT_E2E_BACKEND_TOKEN}")
+          TOKEN=$(printf '%s' "$RESP" | node -e 'const j=JSON.parse(require("fs").readFileSync(0,"utf8"));process.stdout.write(j.access_token||"")')
+          USERID=$(printf '%s' "$RESP" | node -e 'const j=JSON.parse(require("fs").readFileSync(0,"utf8"));process.stdout.write((j.user&&j.user.id)||"")')
+          if [ -z "${TOKEN:-}" ] || [ -z "${USERID:-}" ]; then
+            echo "::error::failed to mint e2e token — response was: ${RESP}"
+            exit 1
+          fi
+          USERJSON=$(printf '{"id":"%s","email":"%s"}' "$USERID" "$EMAIL")
+          echo "::add-mask::$TOKEN"
+          {
+            echo "E2E_TEST_TOKEN<<__E2E_EOF__"
+            echo "$TOKEN"
+            echo "__E2E_EOF__"
+            echo "E2E_TEST_USER_JSON=$USERJSON"
+          } >> "$GITHUB_ENV"
+          echo "Minted e2e session for ${EMAIL} (user ${USERID})"
+
+      # Build the RELEASE APK locally (not debug — assembleDebug needs Metro,
+      # which CI doesn't run). The E2E_MODE bypass reads the inlined token, so
+      # the Maestro YAML needs no deeplink seeding step.
+      - name: Build Android APK locally
+        working-directory: apps/mobile
+        env:
+          EXPO_PUBLIC_E2E_MODE: '1'
+          EXPO_PUBLIC_E2E_TEST_TOKEN: ${{ env.E2E_TEST_TOKEN }}
+          EXPO_PUBLIC_E2E_TEST_USER_JSON: ${{ env.E2E_TEST_USER_JSON }}
+          # The emulator reaches the loopback-only VPT e2e API via 10.0.2.2.
+          # Cleartext for this http:// host is allowed only in e2e builds via
+          # the usesCleartextTraffic toggle in app.config.ts (Step 1).
+          EXPO_PUBLIC_API_URL: ${{ env.VPT_E2E_API_URL }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ -z "${EXPO_PUBLIC_E2E_TEST_TOKEN:-}" ] || [ -z "${EXPO_PUBLIC_E2E_TEST_USER_JSON:-}" ]; then
+            echo "::error::e2e session env is empty — the 'Mint e2e session' step did not run or failed"
+            exit 1
+          fi
+          export PATH="$ANDROID_SDK_ROOT/platform-tools:$ANDROID_SDK_ROOT/cmdline-tools/latest/bin:$PATH"
+          pnpm exec expo prebuild --platform android --non-interactive --no-install
+          # EXPO_PUBLIC_* values are inlined by Metro at bundle time; a changed
+          # env var does NOT invalidate Gradle/Metro caches. On the persistent
+          # self-hosted workspace, clear Metro caches + force the bundle task to
+          # re-run so the current env is inlined.
+          rm -rf "${TMPDIR:-/tmp}"/metro-* "${TMPDIR:-/tmp}"/haste-map-* node_modules/.cache 2>/dev/null || true
+          cd android
+          ./gradlew :app:createBundleReleaseJsAndAssets \
+            --rerun-tasks --no-daemon --console=plain
+          ./gradlew :app:assembleRelease \
+            -x lintVitalAnalyzeRelease -x lintVitalRelease \
+            --no-daemon --console=plain \
+            --build-cache
+          APK="app/build/outputs/apk/release/app-release.apk"
+          ls -lh "$APK"
+          cp "$APK" /tmp/vpt-e2e.apk
+          # Fail fast if the backend URL didn't get inlined into the JS bundle.
+          if ! unzip -p /tmp/vpt-e2e.apk assets/index.android.bundle 2>/dev/null \
+               | strings | grep -aq 'http://10.0.2.2:8010'; then
+            echo "::error::APK bundle is missing http://10.0.2.2:8010 — EXPO_PUBLIC_API_URL was not inlined"
+            exit 1
+          fi
+          echo "APK backend URL verified: http://10.0.2.2:8010"
+
+      - name: Start Android emulator (background)
+        shell: bash
+        run: |
+          set -euo pipefail
+          export PATH="$ANDROID_SDK_ROOT/platform-tools:$ANDROID_SDK_ROOT/emulator:$PATH"
+          adb kill-server || true
+          adb start-server
+          nohup env ANDROID_AVD_HOME="$ANDROID_AVD_HOME" \
+            emulator -avd "$ANDROID_AVD_NAME" \
+              -no-window -no-audio -no-boot-anim -no-snapshot-save \
+              -accel auto \
+              -gpu swiftshader_indirect \
+            > /tmp/emulator.log 2>&1 &
+          echo "emulator pid: $!"
+
+      - name: Wait for emulator
+        shell: bash
+        run: |
+          set -euo pipefail
+          export PATH="$ANDROID_SDK_ROOT/platform-tools:$PATH"
+          adb wait-for-device
+          for i in $(seq 1 60); do
+            BOOTED=$(adb shell getprop sys.boot_completed 2>/dev/null | tr -d '\r' || true)
+            ANIM_DONE=$(adb shell getprop init.svc.bootanim 2>/dev/null | tr -d '\r' || true)
+            if [ "$BOOTED" = "1" ] && [ "$ANIM_DONE" != "running" ]; then
+              echo "emulator booted after $((i * 10))s"
+              adb shell input keyevent 82 || true
+              adb shell settings put global window_animation_scale 0 || true
+              adb shell settings put global transition_animation_scale 0 || true
+              adb shell settings put global animator_duration_scale 0 || true
+              exit 0
+            fi
+            if [ $((i % 3)) -eq 0 ]; then
+              echo "  $((i * 10))s — boot_completed=${BOOTED:-?} bootanim=${ANIM_DONE:-?}"
+            fi
+            sleep 10
+          done
+          echo "::error::emulator failed to boot in 10 minutes"
+          tail -100 /tmp/emulator.log || true
+          exit 1
+
+      - name: Install APK
+        shell: bash
+        run: |
+          export PATH="$ANDROID_SDK_ROOT/platform-tools:$PATH"
+          adb install -r /tmp/vpt-e2e.apk
+
+      - name: Capture cold-launch state
+        shell: bash
+        run: |
+          set -uo pipefail
+          export PATH="$ANDROID_SDK_ROOT/platform-tools:$PATH"
+          mkdir -p /tmp/maestro-debug
+          adb shell pm clear me.ethanasm.vacation_price_tracker || true
+          adb shell am start -W -n me.ethanasm.vacation_price_tracker/.MainActivity || true
+          sleep 8
+          adb exec-out screencap -p > /tmp/maestro-debug/cold-launch.png || true
+          adb shell uiautomator dump /sdcard/cold-launch.xml >/dev/null 2>&1 || true
+          adb pull /sdcard/cold-launch.xml /tmp/maestro-debug/cold-launch.xml || true
+          echo "::group::Cold-launch UI hierarchy (text nodes only)"
+          if [ -f /tmp/maestro-debug/cold-launch.xml ]; then
+            grep -oE 'text="[^"]*"' /tmp/maestro-debug/cold-launch.xml \
+              | grep -v 'text=""' | sort -u | head -50 || true
+          else
+            echo "no UI dump captured"
+          fi
+          echo "::endgroup::"
+          adb shell am force-stop me.ethanasm.vacation_price_tracker || true
+
+      - name: Run Maestro flows
+        shell: bash
+        run: |
+          set -uo pipefail
+          export PATH="$ANDROID_SDK_ROOT/platform-tools:$HOME/.maestro/bin:$PATH"
+          rm -rf /tmp/maestro-debug/.maestro
+          mkdir -p /tmp/maestro-debug
+          # Invoke maestro once per flow with an explicit pm clear between, so
+          # SecureStore values from one flow don't survive into the next on the
+          # AOSP system image (clearState alone proved unreliable in showbook CI).
+          RC=0
+          for flow in apps/mobile/e2e/flows/*.yaml; do
+            echo "::group::pm clear before $(basename "$flow")"
+            adb shell pm clear me.ethanasm.vacation_price_tracker || true
+            sleep 2
+            echo "::endgroup::"
+            maestro test --debug-output /tmp/maestro-debug "$flow" || {
+              status=$?
+              echo "::warning::$(basename "$flow") failed with status $status"
+              RC=$status
+            }
+          done
+          exit $RC
+
+      - name: Summarise Maestro debug output
+        if: failure()
+        shell: bash
+        run: |
+          set -u
+          echo "::group::Maestro debug dir contents"
+          ls -la /tmp/maestro-debug/ 2>/dev/null || echo "no debug dir"
+          echo "::endgroup::"
+          shopt -s nullglob
+          for f in /tmp/maestro-debug/**/*.txt /tmp/maestro-debug/**/*.json /tmp/maestro-debug/**/*.log /tmp/maestro-debug/*.txt /tmp/maestro-debug/*.json /tmp/maestro-debug/*.log; do
+            echo "::group::$f"
+            tail -200 "$f" 2>/dev/null || true
+            echo "::endgroup::"
+          done
+          echo "::group::Screenshots captured"
+          find /tmp/maestro-debug -name '*.png' -printf '%p\n' 2>/dev/null | sort || true
+          echo "::endgroup::"
+
+      - name: Upload Maestro debug artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: maestro-debug-${{ github.run_id }}
+          path: |
+            /tmp/maestro-debug/**
+            /tmp/emulator.log
+          if-no-files-found: ignore
+          retention-days: 7
+
+      - name: Post failure comment on PR
+        if: failure() && github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          RUN_ID: ${{ github.run_id }}
+        shell: bash
+        run: |
+          set -uo pipefail
+          BODY_FILE=$(mktemp)
+          {
+            printf '## Mobile e2e (Android) — failed\n\n'
+            printf '[Workflow run](%s) — see the run log for the failing step.\n\n' "$RUN_URL"
+            printf 'Maestro debug screenshots (if any) are uploaded as the maestro-debug-%s artifact.\n' "$RUN_ID"
+          } > "$BODY_FILE"
+          set +e
+          gh pr comment "$PR_NUMBER" --body-file "$BODY_FILE"
+          echo "gh pr comment exit: $?"
+
+      - name: Publish maestro debug to pr-screenshots branch
+        if: failure() && github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          RUN_ID: ${{ github.run_id }}
+          GH_REPO: ${{ github.repository }}
+        shell: bash
+        run: |
+          set -uo pipefail
+          if [ ! -d /tmp/maestro-debug ]; then
+            echo "no /tmp/maestro-debug — nothing to publish"
+            exit 0
+          fi
+          FLAT=/tmp/maestro-debug-flat
+          rm -rf "$FLAT"; mkdir -p "$FLAT"
+          [ -f /tmp/maestro-debug/cold-launch.png ] && cp /tmp/maestro-debug/cold-launch.png "$FLAT/cold-launch.png"
+          n=1
+          while IFS= read -r -d '' f; do
+            base="$(basename "$f")"
+            flow="$(echo "$base" | sed -E 's/.*\(([^)]+)\)\.png$/\1/' | tr -c '[:alnum:]-' '-')"
+            [ -z "$flow" ] && flow="unknown"
+            cp "$f" "$FLAT/maestro-${flow}-${n}.png"
+            n=$((n + 1))
+          done < <(find /tmp/maestro-debug -name '*.png' -path '*tests*' -print0)
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          # Push the PNGs to an orphan pr-screenshots branch under
+          # mobile-e2e/run-<id>/ using git plumbing (no external uploader
+          # script — VPT has none). Repo is public so raw URLs are fetchable.
+          RUN_DIR="mobile-e2e/run-${RUN_ID}"
+          WT=$(mktemp -d)
+          git fetch origin pr-screenshots:pr-screenshots 2>/dev/null || true
+          if git show-ref --verify --quiet refs/heads/pr-screenshots; then
+            git worktree add "$WT" pr-screenshots
+          else
+            git worktree add --detach "$WT"
+            ( cd "$WT" && git checkout --orphan pr-screenshots && git rm -rf . >/dev/null 2>&1 || true )
+          fi
+          mkdir -p "$WT/$RUN_DIR"
+          cp "$FLAT"/*.png "$WT/$RUN_DIR/" 2>/dev/null || true
+          ( cd "$WT" && git add "$RUN_DIR" && git commit -m "ci: mobile-e2e screenshots run ${RUN_ID}" && git push origin pr-screenshots ) || echo "::warning::screenshot push failed"
+          git worktree remove --force "$WT" || true
+          RAW_BASE="https://raw.githubusercontent.com/${GH_REPO}/pr-screenshots/${RUN_DIR}"
+          BODY_FILE=$(mktemp)
+          {
+            printf '## Mobile e2e debug — %s\n\n' "$RUN_DIR"
+            printf '[Workflow run](%s) failed.\n\n' "$RUN_URL"
+            for img in "$FLAT"/*.png; do
+              [ -e "$img" ] || continue
+              bn=$(basename "$img")
+              printf '![%s](%s/%s)\n' "$bn" "$RAW_BASE" "$bn"
+            done
+          } > "$BODY_FILE"
+          gh pr comment "$PR_NUMBER" --body-file "$BODY_FILE" || echo "::warning::gh pr comment failed"
+
+      - name: Shut down emulator
+        if: always()
+        shell: bash
+        run: |
+          export PATH="$ANDROID_SDK_ROOT/platform-tools:$PATH"
+          adb emu kill || true
+          adb kill-server || true
+          for _ in $(seq 1 30); do
+            pgrep -f "emulator -avd ${ANDROID_AVD_NAME}" >/dev/null || break
+            sleep 1
+          done
+          rm -f "$ANDROID_AVD_HOME/${ANDROID_AVD_NAME}.avd"/*.lock 2>/dev/null || true

--- a/.github/workflows/mobile.yml
+++ b/.github/workflows/mobile.yml
@@ -1,0 +1,74 @@
+name: Mobile
+
+# Lint / typecheck / unit-test gate for the Expo app (apps/mobile) + the mobile
+# release tooling. VPT's web/server CI workflows are scoped to their own
+# projects, so without this workflow the mobile Nx project (and the version-bump
+# script + Maestro flows) get no CI coverage. Kept OUT of the Sonar coverage flow
+# on purpose: sonarqube.yml downloads web + server coverage by commit SHA, and
+# adding a third source reintroduces the cross-workflow zero-coverage fragility
+# documented in CLAUDE.md. The mobile 80% gate is enforced in-job here instead.
+on:
+  push:
+    branches: [main]
+    paths:
+      - "apps/mobile/**"
+      - "scripts/bump-mobile-version.mjs"
+      - "scripts/__tests__/bump-mobile-version.test.mjs"
+      - "infra/docker-compose.e2e.yml"
+      - ".github/workflows/mobile.yml"
+      - ".github/workflows/mobile-deploy.yml"
+      - ".github/workflows/mobile-e2e.yml"
+      - "package.json"
+      - "pnpm-lock.yaml"
+      - "nx.json"
+      - "tsconfig*.json"
+  pull_request:
+    paths:
+      - "apps/mobile/**"
+      - "scripts/bump-mobile-version.mjs"
+      - "scripts/__tests__/bump-mobile-version.test.mjs"
+      - "infra/docker-compose.e2e.yml"
+      - ".github/workflows/mobile.yml"
+      - ".github/workflows/mobile-deploy.yml"
+      - ".github/workflows/mobile-e2e.yml"
+      - "package.json"
+      - "pnpm-lock.yaml"
+      - "nx.json"
+      - "tsconfig*.json"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: mobile-ci-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  checks:
+    name: Lint / typecheck / test (mobile)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9.12.1
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Lint / typecheck / test (mobile, enforces 80% lib/** gate)
+        run: pnpm nx run-many -t lint typecheck test:coverage --projects=mobile
+      - name: Version-bump script unit test
+        run: node --test scripts/__tests__/bump-mobile-version.test.mjs
+      - name: Validate Maestro flow YAML
+        working-directory: apps/mobile
+        run: node e2e/scripts/dry-run.mjs e2e/flows
+      - name: Lint mobile workflows (actionlint)
+        run: |
+          docker run --rm -v "$PWD":/repo --workdir /repo rhysd/actionlint:latest -color \
+            .github/workflows/mobile.yml \
+            .github/workflows/mobile-deploy.yml \
+            .github/workflows/mobile-e2e.yml

--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -1,7 +1,7 @@
-name: Python
+name: Server
 
 on:
-  # Union path filter shared with python.yml so ANY code change runs BOTH
+  # Union path filter shared with web.yml so ANY code change runs BOTH
   # coverage workflows. SonarCloud downloads web + python coverage by commit
   # SHA; if only one workflow ran, the other language's report is missing and
   # Sonar zero-coverages it (tanking Coverage on New Code). Both-or-neither.
@@ -19,8 +19,8 @@ on:
       - "nx.json"
       - "tsconfig*.json"
       - "sonar-project.properties"
-      - ".github/workflows/nextjs.yml"
-      - ".github/workflows/python.yml"
+      - ".github/workflows/web.yml"
+      - ".github/workflows/server.yml"
   pull_request:
     branches: [main]
     paths:
@@ -35,8 +35,8 @@ on:
       - "nx.json"
       - "tsconfig*.json"
       - "sonar-project.properties"
-      - ".github/workflows/nextjs.yml"
-      - ".github/workflows/python.yml"
+      - ".github/workflows/web.yml"
+      - ".github/workflows/server.yml"
 concurrency:
   group: python-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -1,13 +1,13 @@
 name: SonarQube
 
-# Coverage is computed once by the Next.js and Python workflows, which upload
+# Coverage is computed once by the Web and Server workflows, which upload
 # lcov.info / coverage.xml as artifacts. This workflow no longer re-runs any
 # tests — it waits for those workflows, downloads their coverage, and runs only
 # the scan. Triggering on both means it re-scans when the slower one finishes;
 # the concurrency group cancels the earlier, less-complete scan.
 on:
   workflow_run:
-    workflows: ["Next.js", "Python"]
+    workflows: ["Web", "Server"]
     types: [completed]
 
 concurrency:
@@ -32,7 +32,7 @@ jobs:
         uses: dawidd6/action-download-artifact@v6
         with:
           name: web-coverage
-          workflow: nextjs.yml
+          workflow: web.yml
           commit: ${{ github.event.workflow_run.head_sha }}
           path: apps/web/coverage
           if_no_artifact_found: warn
@@ -41,7 +41,7 @@ jobs:
         uses: dawidd6/action-download-artifact@v6
         with:
           name: python-coverage
-          workflow: python.yml
+          workflow: server.yml
           commit: ${{ github.event.workflow_run.head_sha }}
           path: apps
           if_no_artifact_found: warn

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -1,7 +1,7 @@
-name: Next.js
+name: Web
 
 on:
-  # Union path filter shared with python.yml so ANY code change runs BOTH
+  # Union path filter shared with server.yml so ANY code change runs BOTH
   # coverage workflows. SonarCloud downloads web + python coverage by commit
   # SHA; if only one workflow ran, the other language's report is missing and
   # Sonar zero-coverages it (tanking Coverage on New Code). Both-or-neither.
@@ -19,8 +19,8 @@ on:
       - "nx.json"
       - "tsconfig*.json"
       - "sonar-project.properties"
-      - ".github/workflows/nextjs.yml"
-      - ".github/workflows/python.yml"
+      - ".github/workflows/web.yml"
+      - ".github/workflows/server.yml"
   pull_request:
     branches: [main]
     paths:
@@ -35,8 +35,8 @@ on:
       - "nx.json"
       - "tsconfig*.json"
       - "sonar-project.properties"
-      - ".github/workflows/nextjs.yml"
-      - ".github/workflows/python.yml"
+      - ".github/workflows/web.yml"
+      - ".github/workflows/server.yml"
 concurrency:
   group: nextjs-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /.idea
 .env
 .env.prod
+.env.e2e
 .env.*.local
 /backups
 /node_modules

--- a/.superpowers/sdd/ci-refactor-report.md
+++ b/.superpowers/sdd/ci-refactor-report.md
@@ -1,0 +1,93 @@
+# CI Refactor Report
+
+Date: 2026-06-24
+
+## Summary
+
+Renamed the two coverage CI workflows to clearer names, fixed every reference
+across the codebase, and added a new `mobile.yml` workflow for mobile CI coverage.
+
+## Changes
+
+### 1. Workflow renames (via `git mv`)
+- `nextjs.yml` → `web.yml` (display name `Next.js` → `Web`)
+- `python.yml` → `server.yml` (display name `Python` → `Server`)
+
+### 2. `web.yml` and `server.yml` paths lists
+Both files updated so the two self-referencing path entries now point to the new
+filenames (`web.yml`/`server.yml`). The `paths:` lists remain byte-identical
+between the two files (diff: empty).
+
+### 3. `sonarqube.yml` fixes
+- Comment updated: "Next.js and Python workflows" → "Web and Server workflows"
+- `workflows: ["Next.js", "Python"]` → `["Web", "Server"]`
+- Download-artifact `workflow: nextjs.yml` → `workflow: web.yml`
+- Download-artifact `workflow: python.yml` → `workflow: server.yml`
+
+### 4. Doc reference fixes
+- `CLAUDE.md:226`: "Next.js + Python workflows" → "Web + Server workflows"
+- `CLAUDE.md:259`: `` `nextjs.yml`/`python.yml` `` → `` `web.yml`/`server.yml` ``
+- `.claude/skills/creating-prs/SKILL.md:161`: workflow list updated to include
+  `web.yml`, `server.yml`, `mobile.yml`
+- `SECURITY_AUDIT.md:182`: filenames updated to `server.yml` and `web.yml`
+
+### 5. New `.github/workflows/mobile.yml`
+Gates mobile PRs with: Nx lint/typecheck/test:coverage for the `mobile` project
+(enforcing the 80% lib/** coverage threshold), the version-bump unit test, Maestro
+flow YAML dry-run, and actionlint on the three mobile workflows. Intentionally
+excluded from the Sonar coverage flow to avoid cross-workflow zero-coverage
+fragility.
+
+## Verification Results
+
+### Stale-ref grep (must be empty)
+```
+$ grep -rn "nextjs\.yml\|python\.yml" . | grep -v node_modules | grep -v "/.git/" | grep -v "docs/superpowers/plans/" | grep -v "\.nx/"
+(empty — PASS)
+```
+
+### Display-name grep in workflows (must be empty)
+```
+$ grep -rn '"Next.js"\|"Python"' .github/workflows/
+(empty — PASS)
+```
+
+### actionlint (all 6 workflows)
+```
+$ docker run --rm -v "$(git rev-parse --show-toplevel)":/repo --workdir /repo rhysd/actionlint:latest -color \
+    .github/workflows/web.yml .github/workflows/server.yml \
+    .github/workflows/sonarqube.yml .github/workflows/mobile.yml \
+    .github/workflows/mobile-deploy.yml .github/workflows/mobile-e2e.yml
+(no output — exit 0 — PASS)
+```
+
+### Mobile Nx run
+```
+$ pnpm nx run-many -t lint typecheck test:coverage --projects=mobile
+NX  Successfully ran targets lint, typecheck, test:coverage for project mobile
+exit=0 — PASS
+```
+
+### Bump-mobile-version unit test
+```
+$ node --test scripts/__tests__/bump-mobile-version.test.mjs
+pass 9 / 9 — PASS
+```
+
+### Maestro dry-run
+```
+$ cd apps/mobile && node e2e/scripts/dry-run.mjs e2e/flows
+✓ create-trip.yaml  ✓ sign-in.yaml  ✓ trip-detail.yaml  ✓ trips-list.yaml
+4 flow file(s) OK — PASS
+```
+
+## Files Changed
+
+- `.github/workflows/nextjs.yml` → `.github/workflows/web.yml` (renamed + edited)
+- `.github/workflows/python.yml` → `.github/workflows/server.yml` (renamed + edited)
+- `.github/workflows/sonarqube.yml` (3 references updated)
+- `.github/workflows/mobile.yml` (new file)
+- `CLAUDE.md` (2 references updated)
+- `.claude/skills/creating-prs/SKILL.md` (1 reference updated)
+- `SECURITY_AUDIT.md` (1 reference updated)
+- `.superpowers/sdd/ci-refactor-report.md` (this file)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -223,7 +223,7 @@ scoped to `apps/mobile/lib/**` only (screen/layout code under
 
 ### SonarCloud quality gate (run locally before a PR)
 
-CI computes coverage in the Next.js + Python workflows, then a **separate**
+CI computes coverage in the Web + Server workflows, then a **separate**
 SonarQube workflow downloads those reports and scans (`sonar-project.properties`).
 The gate has **several conditions** — Coverage, **Security Rating**, Reliability,
 Maintainability, Duplications — and a PR can fail on any of them.
@@ -256,7 +256,7 @@ can still drop the gate. Use `--scan` to be sure.
 
 **CI invariant — both coverage workflows must run together.** The SonarQube
 workflow downloads web *and* python coverage **by commit SHA**; if only one of
-`nextjs.yml`/`python.yml` ran for a commit, the other language's report is absent
+`web.yml`/`server.yml` ran for a commit, the other language's report is absent
 and Sonar zero-coverages it (this is what tanked Coverage on New Code to 16.9%
 then 25.7%). The two workflows therefore share an **identical union `paths`
 filter** so any code change runs **both** (both-or-neither). When editing either

--- a/SECURITY_AUDIT.md
+++ b/SECURITY_AUDIT.md
@@ -179,7 +179,7 @@ No high-priority security actions required.
 ## Recommended Security Tools
 
 ### For CI/CD Pipeline
-Already wired in `.github/workflows/python.yml` and `.github/workflows/nextjs.yml`:
+Already wired in `.github/workflows/server.yml` and `.github/workflows/web.yml`:
 - `uv run pip-audit` (Python deps)
 - `pnpm audit --prod --ignore-registry-errors` (npm deps)
 

--- a/apps/mobile/.gitignore
+++ b/apps/mobile/.gitignore
@@ -11,3 +11,8 @@ coverage/
 
 # Metro / Babel caches
 .metro-health-check*
+
+# P4 (mobile-cicd): store-submit credentials written to apps/mobile/ at CI
+# time by mobile-deploy.yml. Never commit them.
+play-service-account.json
+asc-api-key.p8

--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -1,4 +1,5 @@
-import type { ExpoConfig } from 'expo/config';
+import type { ExpoConfig } from "expo/config";
+import { type ConfigPlugin, withAndroidManifest } from "expo/config-plugins";
 
 // Google OAuth on native uses the *application id* as the redirect scheme.
 // expo-auth-session's Google provider builds
@@ -11,93 +12,105 @@ import type { ExpoConfig } from 'expo/config';
 // Apple disallows underscores in CFBundleIdentifier; Android keeps underscores
 // (valid there). The two ids therefore differ by design — make sure the iOS
 // vs Android Google OAuth clients are each registered with the matching id.
-const ANDROID_PACKAGE = 'me.ethanasm.vacation_price_tracker';
-const IOS_BUNDLE_ID = 'me.ethanasm.vacation-price-tracker';
+const ANDROID_PACKAGE = "me.ethanasm.vacation_price_tracker";
+const IOS_BUNDLE_ID = "me.ethanasm.vacation-price-tracker";
+
+// The e2e APK reaches the loopback VPT e2e backend over cleartext
+// http://10.0.2.2:8010 (see infra/docker-compose.e2e.yml). Android API 28+
+// release builds block cleartext by default, so the e2e build needs
+// android:usesCleartextTraffic="true" in its manifest. Gated on
+// EXPO_PUBLIC_E2E_MODE (set only by the e2e build profile / mobile-e2e.yml),
+// so prod/preview builds keep the strict HTTPS-only policy.
+const IS_E2E_BUILD = process.env.EXPO_PUBLIC_E2E_MODE === "1";
+
+const withE2EAndroidCleartext: ConfigPlugin = (cfg) =>
+	withAndroidManifest(cfg, (manifestCfg) => {
+		const application = manifestCfg.modResults.manifest.application?.[0];
+		if (application) {
+			application.$["android:usesCleartextTraffic"] = "true";
+		}
+		return manifestCfg;
+	});
 
 const config: ExpoConfig = {
-  name: 'Price Tracker',
-  slug: 'vacation-price-tracker',
-  owner: 'ethanasm',
-  // runtimeVersion below derives the expo-updates runtime from this string.
-  // P4 owns version bumps; foundation ships 0.1.0.
-  version: '0.1.0',
-  orientation: 'portrait',
-  icon: './assets/icon.png',
-  scheme: ['vpt', ANDROID_PACKAGE],
-  userInterfaceStyle: 'light',
-  ios: {
-    bundleIdentifier: IOS_BUNDLE_ID,
-    supportsTablet: true,
-    // ios.config must be a defined object — Expo's withUsesNonExemptEncryption
-    // plugin does `'usesNonExemptEncryption' in config.ios.config`.
-    config: {
-      usesNonExemptEncryption: false,
-    },
-    infoPlist: {
-      UISupportedInterfaceOrientations: ['UIInterfaceOrientationPortrait'],
-      ITSAppUsesNonExemptEncryption: false,
-      // The iOS simulator hits the FastAPI dev server on localhost over the
-      // dev cert; scope the insecure exception to localhost so prod policy
-      // stays strict.
-      NSAppTransportSecurity: {
-        NSAllowsLocalNetworking: true,
-        NSExceptionDomains: {
-          localhost: {
-            NSIncludesSubdomains: true,
-            NSExceptionAllowsInsecureHTTPLoads: true,
-          },
-        },
-      },
-    },
-  },
-  android: {
-    package: ANDROID_PACKAGE,
-    adaptiveIcon: {
-      foregroundImage: './assets/adaptive-icon.png',
-      backgroundColor: '#7C3AED',
-    },
-    // P4 (mobile-cicd): the e2e APK reaches the emulator-host VPT e2e backend
-    // over cleartext http://10.0.2.2:8010. Allow cleartext ONLY in e2e builds
-    // (EXPO_PUBLIC_E2E_MODE=1, set by the e2e build profile / mobile-e2e.yml);
-    // prod/preview builds keep cleartext disabled.
-    usesCleartextTraffic: process.env.EXPO_PUBLIC_E2E_MODE === '1',
-  },
-  plugins: [
-    'expo-router',
-    'expo-font',
-    'expo-secure-store',
-    'expo-notifications',
-    [
-      'expo-splash-screen',
-      {
-        // image MUST stay set or the release Android build fails at
-        // processReleaseResources ("drawable/splashscreen_logo not found").
-        image: './assets/splash.png',
-        imageWidth: 200,
-        backgroundColor: '#FAF8FF',
-        resizeMode: 'contain',
-      },
-    ],
-  ],
-  experiments: {
-    typedRoutes: true,
-  },
-  runtimeVersion: {
-    policy: 'appVersion',
-  },
-  // P4 (mobile-cicd): EAS Update wiring. expo-updates resolves OTA bundles from
-  // this URL; the runtime version is derived from `version` above via the
-  // runtimeVersion.policy='appVersion' setting.
-  updates: {
-    url: 'https://u.expo.dev/6ab19d8f-51fd-4bce-b47f-4b2828209c04',
-  },
-  extra: {
-    // Links this app to the EAS project (created via `eas init`). Required for
-    // `eas build`/`eas update` and Expo push tokens.
-    eas: {
-      projectId: '6ab19d8f-51fd-4bce-b47f-4b2828209c04',
-    },
-  },
+	name: "Price Tracker",
+	slug: "vacation-price-tracker",
+	owner: "ethanasm",
+	// runtimeVersion below derives the expo-updates runtime from this string.
+	// P4 owns version bumps; foundation ships 0.1.0.
+	version: "0.1.0",
+	orientation: "portrait",
+	icon: "./assets/icon.png",
+	scheme: ["vpt", ANDROID_PACKAGE],
+	userInterfaceStyle: "light",
+	ios: {
+		bundleIdentifier: IOS_BUNDLE_ID,
+		supportsTablet: true,
+		// ios.config must be a defined object — Expo's withUsesNonExemptEncryption
+		// plugin does `'usesNonExemptEncryption' in config.ios.config`.
+		config: {
+			usesNonExemptEncryption: false,
+		},
+		infoPlist: {
+			UISupportedInterfaceOrientations: ["UIInterfaceOrientationPortrait"],
+			ITSAppUsesNonExemptEncryption: false,
+			// The iOS simulator hits the FastAPI dev server on localhost over the
+			// dev cert; scope the insecure exception to localhost so prod policy
+			// stays strict.
+			NSAppTransportSecurity: {
+				NSAllowsLocalNetworking: true,
+				NSExceptionDomains: {
+					localhost: {
+						NSIncludesSubdomains: true,
+						NSExceptionAllowsInsecureHTTPLoads: true,
+					},
+				},
+			},
+		},
+	},
+	android: {
+		package: ANDROID_PACKAGE,
+		adaptiveIcon: {
+			foregroundImage: "./assets/adaptive-icon.png",
+			backgroundColor: "#7C3AED",
+		},
+	},
+	plugins: [
+		"expo-router",
+		"expo-font",
+		"expo-secure-store",
+		"expo-notifications",
+		[
+			"expo-splash-screen",
+			{
+				// image MUST stay set or the release Android build fails at
+				// processReleaseResources ("drawable/splashscreen_logo not found").
+				image: "./assets/splash.png",
+				imageWidth: 200,
+				backgroundColor: "#FAF8FF",
+				resizeMode: "contain",
+			},
+		],
+	],
+	experiments: {
+		typedRoutes: true,
+	},
+	runtimeVersion: {
+		policy: "appVersion",
+	},
+	// P4 (mobile-cicd): EAS Update wiring. expo-updates resolves OTA bundles from
+	// this URL; the runtime version is derived from `version` above via the
+	// runtimeVersion.policy='appVersion' setting.
+	updates: {
+		url: "https://u.expo.dev/6ab19d8f-51fd-4bce-b47f-4b2828209c04",
+	},
+	extra: {
+		// Links this app to the EAS project (created via `eas init`). Required for
+		// `eas build`/`eas update` and Expo push tokens.
+		eas: {
+			projectId: "6ab19d8f-51fd-4bce-b47f-4b2828209c04",
+		},
+	},
 };
 
-export default config;
+export default IS_E2E_BUILD ? withE2EAndroidCleartext(config) : config;

--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -56,6 +56,11 @@ const config: ExpoConfig = {
       foregroundImage: './assets/adaptive-icon.png',
       backgroundColor: '#7C3AED',
     },
+    // P4 (mobile-cicd): the e2e APK reaches the emulator-host VPT e2e backend
+    // over cleartext http://10.0.2.2:8010. Allow cleartext ONLY in e2e builds
+    // (EXPO_PUBLIC_E2E_MODE=1, set by the e2e build profile / mobile-e2e.yml);
+    // prod/preview builds keep cleartext disabled.
+    usesCleartextTraffic: process.env.EXPO_PUBLIC_E2E_MODE === '1',
   },
   plugins: [
     'expo-router',

--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -80,10 +80,15 @@ const config: ExpoConfig = {
   runtimeVersion: {
     policy: 'appVersion',
   },
+  // P4 (mobile-cicd): EAS Update wiring. expo-updates resolves OTA bundles from
+  // this URL; the runtime version is derived from `version` above via the
+  // runtimeVersion.policy='appVersion' setting.
+  updates: {
+    url: 'https://u.expo.dev/6ab19d8f-51fd-4bce-b47f-4b2828209c04',
+  },
   extra: {
     // Links this app to the EAS project (created via `eas init`). Required for
-    // `eas build`/`eas update` and Expo push tokens. `updates.url` is still
-    // intentionally absent — P4 (mobile-cicd) adds it with the OTA wiring.
+    // `eas build`/`eas update` and Expo push tokens.
     eas: {
       projectId: '6ab19d8f-51fd-4bce-b47f-4b2828209c04',
     },

--- a/apps/mobile/e2e/config.yaml
+++ b/apps/mobile/e2e/config.yaml
@@ -1,0 +1,24 @@
+# Maestro project-level config for the VPT mobile app.
+#
+# Discovery: every YAML under flows/ is a flow file Maestro executes when this
+# directory is passed to `maestro test`. .github/workflows/mobile-e2e.yml runs
+# the whole directory against a self-hosted Android emulator nightly + on
+# push-to-main + on PRs labeled `mobile-visual`.
+#
+# Bundle id: must match ios.bundleIdentifier (me.ethanasm.vacation-price-tracker)
+# and android.package (me.ethanasm.vacation_price_tracker) in
+# apps/mobile/app.config.ts. Kept in sync manually — if either id changes,
+# update this file too.
+#
+# `e2e` builds set EXPO_PUBLIC_E2E_MODE=1 (see apps/mobile/eas.json), which
+# flips apps/mobile/lib/auth.ts into the Maestro bypass branch: the sign-in tap
+# loads a pre-baked VPT JWT instead of running real Google OAuth. Production
+# builds ship with the var unset, so this branch is dead code there.
+flows:
+  - flows/
+
+appId: me.ethanasm.vacation_price_tracker
+
+# Wider implicit waitFor budget — first launch warms the REST client and
+# restores the SecureStore session, both of which take a few seconds cold in CI.
+defaultTimeout: 30000

--- a/apps/mobile/e2e/flows/create-trip.yaml
+++ b/apps/mobile/e2e/flows/create-trip.yaml
@@ -1,0 +1,72 @@
+# Create-trip flow — Maestro
+#
+# End-to-end create path: sign-in, open the create-trip form, fill required
+# fields, submit, verify the backend round-trip. The create call hits the e2e
+# backend (infra/docker-compose.e2e.yml) which the emulator reaches at
+# EXPO_PUBLIC_API_URL=http://10.0.2.2:8010 — the emulator NAT alias for the
+# runner host's loopback.
+#
+# The created trip ("Maestro Test Trip") persists in the e2e database across
+# flows/runs and is the `trip-card` target for trips-list / trip-detail. The
+# create contract has NO saved-confirmation testID — the proof is the new name
+# appearing back in `trips-list` after navigating to Trips. If that final
+# assertion fails while the form steps pass, suspect the backend: stack down,
+# P5 Bearer-header support not merged, or allowlist drift in .env.e2e.
+appId: me.ethanasm.vacation_price_tracker
+name: create-trip
+tags:
+  - critical
+  - write
+---
+- launchApp:
+    clearState: true
+    clearKeychain: true
+
+- scrollUntilVisible:
+    element:
+      id: "sign-in-google-button"
+    direction: DOWN
+    visibilityPercentage: 60
+    waitToSettleTimeoutMs: 500
+    timeout: 30000
+- tapOn:
+    id: "sign-in-google-button"
+
+- assertVisible:
+    text: "Trips"
+
+# Open the create-trip form via the FAB.
+- tapOn:
+    id: "new-trip-fab"
+
+- assertVisible:
+    id: "create-trip-name-input"
+
+- tapOn:
+    id: "create-trip-name-input"
+- inputText: "Maestro Test Trip"
+
+- tapOn:
+    id: "create-trip-origin-input"
+- inputText: "SEA"
+
+- tapOn:
+    id: "create-trip-destination-input"
+- inputText: "Maui"
+
+# Dismiss the IME before submitting so Gboard's content-description elements
+# don't compete with the submit control.
+- hideKeyboard
+
+- tapOn:
+    id: "create-trip-submit"
+
+# Create contract: no saved-confirmation card. Navigate back to Trips and assert
+# the new trip's NAME is visible inside `trips-list` — the server-fed list
+# showing the row proves the create committed and survives a refetch.
+- tapOn:
+    text: "Trips"
+- assertVisible:
+    id: "trips-list"
+- assertVisible:
+    text: "Maestro Test Trip"

--- a/apps/mobile/e2e/flows/sign-in.yaml
+++ b/apps/mobile/e2e/flows/sign-in.yaml
@@ -1,0 +1,48 @@
+# Sign-in flow — Maestro
+#
+# The `e2e` build profile (apps/mobile/eas.json) + the mobile-e2e workflow set:
+#   EXPO_PUBLIC_E2E_MODE=1            — flip lib/auth.ts into bypass mode
+#   EXPO_PUBLIC_E2E_TEST_TOKEN        — pre-baked VPT JWT
+#   EXPO_PUBLIC_E2E_TEST_USER_JSON    — pre-baked user JSON
+#
+# These are inlined at build time, so the auth helper returns the bundled
+# session as soon as the user taps "Sign in with Google" — no deeplink seeding.
+# The bypass guards on EXPO_PUBLIC_E2E_MODE === '1' so it's dead code in store
+# builds.
+appId: me.ethanasm.vacation_price_tracker
+name: sign-in
+tags:
+  - critical
+  - auth
+---
+- launchApp:
+    clearState: true
+    clearKeychain: true
+
+# The CTA can sit below the fold on Pixel-6-sized AVDs; scroll it into view
+# before tapping. Accept partial visibility + let each scroll settle so a cold
+# launch where the CTA lands under the gesture nav doesn't time out at 100%.
+- scrollUntilVisible:
+    element:
+      id: "sign-in-google-button"
+    direction: DOWN
+    visibilityPercentage: 60
+    waitToSettleTimeoutMs: 500
+    timeout: 30000
+
+- assertVisible:
+    id: "sign-in-google-button"
+
+- tapOn:
+    id: "sign-in-google-button"
+
+# After the bypass writes the cached session and re-renders, the auth gate
+# routes to the tab shell. Assert the three Aurora tabs + the create-trip FAB.
+- assertVisible:
+    text: "Trips"
+- assertVisible:
+    text: "Alerts"
+- assertVisible:
+    text: "Chat"
+- assertVisible:
+    id: "new-trip-fab"

--- a/apps/mobile/e2e/flows/trip-detail.yaml
+++ b/apps/mobile/e2e/flows/trip-detail.yaml
@@ -1,0 +1,42 @@
+# Trip-detail flow — Maestro
+#
+# Opens the seeded trip and verifies the detail screen renders its title and the
+# stat blocks. Depends on a `trip-card` row = "Maestro Test Trip" from
+# create-trip.yaml (Maestro taps the first `trip-card` match).
+appId: me.ethanasm.vacation_price_tracker
+name: trip-detail
+tags:
+  - critical
+  - read
+---
+- launchApp:
+    clearState: true
+    clearKeychain: true
+
+- scrollUntilVisible:
+    element:
+      id: "sign-in-google-button"
+    direction: DOWN
+    visibilityPercentage: 60
+    waitToSettleTimeoutMs: 500
+    timeout: 30000
+- tapOn:
+    id: "sign-in-google-button"
+
+- assertVisible:
+    text: "Trips"
+
+- tapOn:
+    id: "trip-card"
+
+# Detail screen mounted: the seeded trip's title plus the three Aurora stat
+# blocks (flight / hotel / total) confirm the detail screen and its price block
+# loaded.
+- assertVisible:
+    text: "Maestro Test Trip"
+- assertVisible:
+    id: "trip-detail-flight-stat"
+- assertVisible:
+    id: "trip-detail-hotel-stat"
+- assertVisible:
+    id: "trip-detail-total-stat"

--- a/apps/mobile/e2e/flows/trips-list.yaml
+++ b/apps/mobile/e2e/flows/trips-list.yaml
@@ -1,0 +1,40 @@
+# Trips-list flow — Maestro
+#
+# Verifies the trips list loads from the e2e backend. The seeded e2e trip
+# ("Maestro Test Trip") is created by create-trip.yaml and persists in the e2e
+# database across flows/runs, so a `trip-card` row renders here. If this
+# assertion fails while sign-in passes, suspect the backend: e2e stack down, or
+# P5's Bearer-header support not yet merged (the bearer token 401s → empty trips
+# list). See .github/workflows/mobile-e2e.yml § "Mint e2e session".
+appId: me.ethanasm.vacation_price_tracker
+name: trips-list
+tags:
+  - critical
+  - read
+---
+- launchApp:
+    clearState: true
+    clearKeychain: true
+
+- scrollUntilVisible:
+    element:
+      id: "sign-in-google-button"
+    direction: DOWN
+    visibilityPercentage: 60
+    waitToSettleTimeoutMs: 500
+    timeout: 30000
+- tapOn:
+    id: "sign-in-google-button"
+
+- assertVisible:
+    text: "Trips"
+
+# The trips list is server-fed; the seeded trip appearing proves the bearer
+# round-trip and a real refetch, not just an optimistic cache. `trip-card` is
+# the bare row testID — Maestro matches the first one.
+- assertVisible:
+    id: "trips-list"
+- assertVisible:
+    id: "trip-card"
+- assertVisible:
+    text: "Maestro Test Trip"

--- a/apps/mobile/e2e/scripts/dry-run.mjs
+++ b/apps/mobile/e2e/scripts/dry-run.mjs
@@ -1,0 +1,65 @@
+#!/usr/bin/env node
+// Validates Maestro flow YAML without launching a device. Maestro has no
+// --dry-run flag, so we parse each file as a two-document YAML (config +
+// commands) and sanity-check the shape.
+
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { parseAllDocuments } from 'yaml';
+
+const root = resolve(process.argv[2] ?? 'e2e/flows');
+
+function collectFlowFiles(target) {
+  const stat = statSync(target);
+  if (stat.isFile()) return target.endsWith('.yaml') || target.endsWith('.yml') ? [target] : [];
+  return readdirSync(target).flatMap((name) => collectFlowFiles(join(target, name)));
+}
+
+const files = collectFlowFiles(root);
+if (files.length === 0) {
+  console.error(`No flow files found under ${root}`);
+  process.exit(1);
+}
+
+let failed = 0;
+for (const file of files) {
+  const source = readFileSync(file, 'utf8');
+  const docs = parseAllDocuments(source, { prettyErrors: true });
+
+  const errors = docs.flatMap((d) => d.errors);
+  if (errors.length > 0) {
+    console.error(`✗ ${file}`);
+    for (const err of errors) console.error(`  ${err.message}`);
+    failed++;
+    continue;
+  }
+
+  if (docs.length !== 2) {
+    console.error(`✗ ${file}: expected 2 YAML documents (config + commands), got ${docs.length}`);
+    failed++;
+    continue;
+  }
+
+  const config = docs[0].toJS();
+  const commands = docs[1].toJS();
+
+  if (!config || typeof config.appId !== 'string' || config.appId.length === 0) {
+    console.error(`✗ ${file}: missing or invalid appId in config document`);
+    failed++;
+    continue;
+  }
+
+  if (!Array.isArray(commands) || commands.length === 0) {
+    console.error(`✗ ${file}: commands document must be a non-empty list`);
+    failed++;
+    continue;
+  }
+
+  console.log(`✓ ${file} (${commands.length} steps, appId=${config.appId})`);
+}
+
+if (failed > 0) {
+  console.error(`\n${failed} flow file(s) failed validation`);
+  process.exit(1);
+}
+console.log(`\n${files.length} flow file(s) OK`);

--- a/apps/mobile/e2e/scripts/dry-run.mjs
+++ b/apps/mobile/e2e/scripts/dry-run.mjs
@@ -3,63 +3,72 @@
 // --dry-run flag, so we parse each file as a two-document YAML (config +
 // commands) and sanity-check the shape.
 
-import { readdirSync, readFileSync, statSync } from 'node:fs';
-import { join, resolve } from 'node:path';
-import { parseAllDocuments } from 'yaml';
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { parseAllDocuments } from "yaml";
 
-const root = resolve(process.argv[2] ?? 'e2e/flows');
+const root = resolve(process.argv[2] ?? "e2e/flows");
 
 function collectFlowFiles(target) {
-  const stat = statSync(target);
-  if (stat.isFile()) return target.endsWith('.yaml') || target.endsWith('.yml') ? [target] : [];
-  return readdirSync(target).flatMap((name) => collectFlowFiles(join(target, name)));
+	const stat = statSync(target);
+	if (stat.isFile())
+		return target.endsWith(".yaml") || target.endsWith(".yml") ? [target] : [];
+	return readdirSync(target).flatMap((name) =>
+		collectFlowFiles(join(target, name)),
+	);
 }
 
 const files = collectFlowFiles(root);
 if (files.length === 0) {
-  console.error(`No flow files found under ${root}`);
-  process.exit(1);
+	console.error(`No flow files found under ${root}`);
+	process.exit(1);
 }
 
 let failed = 0;
 for (const file of files) {
-  const source = readFileSync(file, 'utf8');
-  const docs = parseAllDocuments(source, { prettyErrors: true });
+	const source = readFileSync(file, "utf8");
+	const docs = parseAllDocuments(source, { prettyErrors: true });
 
-  const errors = docs.flatMap((d) => d.errors);
-  if (errors.length > 0) {
-    console.error(`✗ ${file}`);
-    for (const err of errors) console.error(`  ${err.message}`);
-    failed++;
-    continue;
-  }
+	const errors = docs.flatMap((d) => d.errors);
+	if (errors.length > 0) {
+		console.error(`✗ ${file}`);
+		for (const err of errors) console.error(`  ${err.message}`);
+		failed++;
+		continue;
+	}
 
-  if (docs.length !== 2) {
-    console.error(`✗ ${file}: expected 2 YAML documents (config + commands), got ${docs.length}`);
-    failed++;
-    continue;
-  }
+	if (docs.length !== 2) {
+		console.error(
+			`✗ ${file}: expected 2 YAML documents (config + commands), got ${docs.length}`,
+		);
+		failed++;
+		continue;
+	}
 
-  const config = docs[0].toJS();
-  const commands = docs[1].toJS();
+	const config = docs[0].toJS();
+	const commands = docs[1].toJS();
 
-  if (!config || typeof config.appId !== 'string' || config.appId.length === 0) {
-    console.error(`✗ ${file}: missing or invalid appId in config document`);
-    failed++;
-    continue;
-  }
+	if (
+		!config ||
+		typeof config.appId !== "string" ||
+		config.appId.length === 0
+	) {
+		console.error(`✗ ${file}: missing or invalid appId in config document`);
+		failed++;
+		continue;
+	}
 
-  if (!Array.isArray(commands) || commands.length === 0) {
-    console.error(`✗ ${file}: commands document must be a non-empty list`);
-    failed++;
-    continue;
-  }
+	if (!Array.isArray(commands) || commands.length === 0) {
+		console.error(`✗ ${file}: commands document must be a non-empty list`);
+		failed++;
+		continue;
+	}
 
-  console.log(`✓ ${file} (${commands.length} steps, appId=${config.appId})`);
+	console.log(`✓ ${file} (${commands.length} steps, appId=${config.appId})`);
 }
 
 if (failed > 0) {
-  console.error(`\n${failed} flow file(s) failed validation`);
-  process.exit(1);
+	console.error(`\n${failed} flow file(s) failed validation`);
+	process.exit(1);
 }
 console.log(`\n${files.length} flow file(s) OK`);

--- a/apps/mobile/eas.json
+++ b/apps/mobile/eas.json
@@ -24,9 +24,48 @@
     "production": {
       "extends": "base",
       "channel": "production"
+    },
+    "preview-store": {
+      "extends": "base",
+      "distribution": "store",
+      "autoIncrement": true,
+      "android": {
+        "buildType": "app-bundle"
+      }
+    },
+    "e2e": {
+      "extends": "preview",
+      "distribution": "internal",
+      "channel": "e2e",
+      "env": {
+        "EXPO_PUBLIC_E2E_MODE": "1"
+      },
+      "ios": {
+        "simulator": true
+      },
+      "android": {
+        "buildType": "apk"
+      }
     }
   },
   "submit": {
-    "production": {}
+    "production": {
+      "android": {
+        "track": "production",
+        "serviceAccountKeyPath": "./play-service-account.json"
+      },
+      "ios": {
+        "ascApiKeyPath": "./asc-api-key.p8"
+      }
+    },
+    "preview-store": {
+      "android": {
+        "track": "internal",
+        "serviceAccountKeyPath": "./play-service-account.json"
+      },
+      "ios": {
+        "ascApiKeyPath": "./asc-api-key.p8"
+      }
+    }
   }
 }

--- a/apps/mobile/eas.json
+++ b/apps/mobile/eas.json
@@ -1,71 +1,71 @@
 {
-  "cli": {
-    "appVersionSource": "local"
-  },
-  "build": {
-    "base": {
-      "env": {
-        "EXPO_PUBLIC_API_URL": "https://vacation-price-tracker.ethanasm.me",
-        "EXPO_PUBLIC_GOOGLE_OAUTH_CLIENT_ID_IOS": "222563763412-ba4ejjpfgdvq3pl64hrnf0u09sap919q.apps.googleusercontent.com",
-        "EXPO_PUBLIC_GOOGLE_OAUTH_CLIENT_ID_ANDROID": "222563763412-9qslaeisquai4hsi930c2bihcj3p34bk.apps.googleusercontent.com",
-        "EXPO_PUBLIC_GOOGLE_OAUTH_CLIENT_ID_WEB": "222563763412-fuonu9krvmvpvpf4dq4m2ggriu8gv113.apps.googleusercontent.com"
-      }
-    },
-    "development": {
-      "extends": "base",
-      "developmentClient": true,
-      "distribution": "internal"
-    },
-    "preview": {
-      "extends": "base",
-      "distribution": "internal",
-      "channel": "preview"
-    },
-    "production": {
-      "extends": "base",
-      "channel": "production"
-    },
-    "preview-store": {
-      "extends": "base",
-      "distribution": "store",
-      "autoIncrement": true,
-      "android": {
-        "buildType": "app-bundle"
-      }
-    },
-    "e2e": {
-      "extends": "preview",
-      "distribution": "internal",
-      "channel": "e2e",
-      "env": {
-        "EXPO_PUBLIC_E2E_MODE": "1"
-      },
-      "ios": {
-        "simulator": true
-      },
-      "android": {
-        "buildType": "apk"
-      }
-    }
-  },
-  "submit": {
-    "production": {
-      "android": {
-        "track": "production",
-        "serviceAccountKeyPath": "./play-service-account.json"
-      },
-      "ios": {
-        "ascApiKeyPath": "./asc-api-key.p8"
-      }
-    },
-    "preview-store": {
-      "android": {
-        "track": "internal",
-        "serviceAccountKeyPath": "./play-service-account.json"
-      },
-      "ios": {
-        "ascApiKeyPath": "./asc-api-key.p8"
-      }
-    }
-  }
+	"cli": {
+		"appVersionSource": "local"
+	},
+	"build": {
+		"base": {
+			"env": {
+				"EXPO_PUBLIC_API_URL": "https://vacation-price-tracker.ethanasm.me",
+				"EXPO_PUBLIC_GOOGLE_OAUTH_CLIENT_ID_IOS": "222563763412-ba4ejjpfgdvq3pl64hrnf0u09sap919q.apps.googleusercontent.com",
+				"EXPO_PUBLIC_GOOGLE_OAUTH_CLIENT_ID_ANDROID": "222563763412-9qslaeisquai4hsi930c2bihcj3p34bk.apps.googleusercontent.com",
+				"EXPO_PUBLIC_GOOGLE_OAUTH_CLIENT_ID_WEB": "222563763412-fuonu9krvmvpvpf4dq4m2ggriu8gv113.apps.googleusercontent.com"
+			}
+		},
+		"development": {
+			"extends": "base",
+			"developmentClient": true,
+			"distribution": "internal"
+		},
+		"preview": {
+			"extends": "base",
+			"distribution": "internal",
+			"channel": "preview"
+		},
+		"production": {
+			"extends": "base",
+			"channel": "production"
+		},
+		"preview-store": {
+			"extends": "base",
+			"distribution": "store",
+			"autoIncrement": true,
+			"android": {
+				"buildType": "app-bundle"
+			}
+		},
+		"e2e": {
+			"extends": "preview",
+			"distribution": "internal",
+			"channel": "e2e",
+			"env": {
+				"EXPO_PUBLIC_E2E_MODE": "1"
+			},
+			"ios": {
+				"simulator": true
+			},
+			"android": {
+				"buildType": "apk"
+			}
+		}
+	},
+	"submit": {
+		"production": {
+			"android": {
+				"track": "production",
+				"serviceAccountKeyPath": "./play-service-account.json"
+			},
+			"ios": {
+				"ascApiKeyPath": "./asc-api-key.p8"
+			}
+		},
+		"preview-store": {
+			"android": {
+				"track": "internal",
+				"serviceAccountKeyPath": "./play-service-account.json"
+			},
+			"ios": {
+				"ascApiKeyPath": "./asc-api-key.p8"
+			}
+		}
+	}
 }

--- a/docs/mobile-cicd.md
+++ b/docs/mobile-cicd.md
@@ -1,0 +1,158 @@
+# Mobile CI/CD — one-time setup
+
+This is the operator runbook for the mobile pipeline added in plan P4
+(`docs/superpowers/plans/2026-06-23-mobile-cicd.md`). The two workflows are
+`mobile-deploy.yml` (EAS OTA + gated store release) and `mobile-e2e.yml`
+(self-hosted Android Maestro). None of this runs until the prerequisites below
+are provisioned.
+
+## 1. One-time EAS project setup
+
+The EAS project is already linked — `extra.eas.projectId` and `updates.url` are
+set to the real project UUID (`6ab19d8f-51fd-4bce-b47f-4b2828209c04`) in
+`apps/mobile/app.config.ts`. **Do not run `eas init`** — doing so would
+overwrite the existing project link.
+
+The only one-time steps remaining are:
+
+**a) Generate an EAS access token for CI:**
+
+```bash
+eas-cli token:create   # or expo.dev → Account Settings → Access Tokens
+```
+
+Save it as the `EXPO_TOKEN` GitHub repo secret.
+
+**b) Validate the build profiles resolve (no build is queued):**
+
+```bash
+EXPO_TOKEN=… pnpm dlx eas-cli config --profile preview-store --platform android
+EXPO_TOKEN=… pnpm dlx eas-cli config --profile preview-store --platform ios
+```
+
+**c) iOS credentials (one-time, interactive — CI can't answer the prompts):**
+
+```bash
+pnpm dlx eas-cli build --profile preview-store --platform ios
+```
+
+Let EAS generate the App Store distribution cert + provisioning profile.
+
+## 2. Confirm bundle ids match store records
+
+The prod domain and all three Google OAuth client IDs are already configured in
+`apps/mobile/eas.json` (real values, not placeholders). These same values appear
+in the OTA step of `.github/workflows/mobile-deploy.yml`; if the prod API domain
+or OAuth client IDs are ever rotated, update both files in sync.
+
+The only remaining confirmation before the first store submit is that the bundle
+ids in `apps/mobile/eas.json` and `apps/mobile/app.config.ts` match the app
+records in App Store Connect and Play Console:
+
+- **iOS:** `me.ethanasm.vacation-price-tracker`
+- **Android:** `me.ethanasm.vacation_price_tracker`
+
+## 3. GitHub repo secrets
+
+Settings → Secrets and variables → Actions → Secrets:
+
+| Secret | Used by | Notes |
+|---|---|---|
+| `EXPO_TOKEN` | both workflows | EAS access token. |
+| `PLAY_SERVICE_ACCOUNT_JSON` | mobile-deploy (Android submit) | Service-account key JSON, Play "Manage testing track releases". |
+| `ASC_API_KEY_P8` | mobile-deploy (iOS submit) | App Store Connect API .p8 contents. |
+| `ASC_API_KEY_ID` | mobile-deploy (iOS submit) | Key id of the .p8. |
+| `ASC_API_KEY_ISSUER_ID` | mobile-deploy (iOS submit) | Issuer id from ASC Integrations. |
+| `ASC_APP_ID` | mobile-deploy (iOS submit) | Numeric Apple ID of the VPT app record. |
+| `RELEASE_DEPLOY_KEY` | mobile-deploy (version bump push) | Recommended. Write-access deploy key; check "Deploy keys" in the branch ruleset bypass list. |
+| `RELEASE_PUSH_TOKEN` | mobile-deploy (version bump push) | Alternative to the deploy key: a fine-grained PAT (Contents: read/write) from a bypass-listed actor. |
+| `VPT_E2E_BACKEND_TOKEN` | mobile-e2e (session mint) | Shared secret the e2e backend's `/v1/e2e/mint-token` endpoint checks against the `X-E2E-Token` request header. Same value set on the `vpt-e2e` api service. |
+| `RESEND_API_KEY` | mobile-deploy (failure email, optional) | Same value as `.env.prod`. |
+| `EMAIL_FROM` | mobile-deploy (failure email, optional) | Verified Resend sender. |
+| `ADMIN_EMAILS` | mobile-deploy (failure email, optional) | Comma-separated recipients. |
+
+## 4. Release approval gate (`mobile-release` environment)
+
+`mobile-deploy.yml`'s `release` job targets the `mobile-release` environment.
+GitHub auto-creates it (no protection) on first run, so releases ship
+immediately until you arm the gate:
+
+Settings → Environments → `mobile-release` → check **Required reviewers** → add
+yourself → Save protection rules.
+
+With a reviewer set, every store release pauses before the version bump / EAS
+build / store submit until approved. Reject (or let the 30-day window lapse) and
+the run dies clean — no bump, no tag, no build, no upload.
+
+## 5. Versioning — branch-ruleset bypass for the version-bump push
+
+The bump commit (`chore(release): mobile vX.Y.Z [skip ci]`) is pushed back to
+`main`, which has a required-PR ruleset. The built-in `github-actions` app
+cannot be bypass-listed, so either:
+
+- (recommended) add a write-access **deploy key** to the repo, check **Deploy
+  keys** in the ruleset's bypass list, and save the private half as
+  `RELEASE_DEPLOY_KEY`; or
+- save a bypass-listed actor's fine-grained PAT as `RELEASE_PUSH_TOKEN`.
+
+`[skip ci]` in the bump message prevents the push from re-triggering CI.
+
+## 6. Self-hosted Android runner (mobile-e2e)
+
+`mobile-e2e.yml` runs on the existing self-hosted `vpt-prod` runner (the one
+`deploy.yml` uses). Add Android tooling once:
+
+```bash
+# On the prod box:
+bash scripts/setup-runner-android.sh   # Android SDK + AVD (vpt_e2e) + Maestro
+```
+
+Optionally set repo variables `ANDROID_SDK_ROOT` (default `/opt/android-sdk`)
+and `ANDROID_AVD_HOME`.
+
+## 7. VPT e2e backend stack (one-time bring-up)
+
+`mobile-e2e.yml` mints its bearer session from an **isolated** VPT e2e backend,
+NOT prod. The compose file `infra/docker-compose.e2e.yml` is authored by P4
+(Task 5) — it defines the `vpt-e2e` stack (own database `vacation_tracker_e2e`,
+own `SECRET_KEY`, `E2E_MODE=1` on the api, a sign-in allowlist pinned to
+`e2e@vpt.test`, the api on loopback `127.0.0.1:8010` which the emulator reaches
+at `http://10.0.2.2:8010`).
+
+**One-time operator bring-up on the prod box** (this is the human/ops step; the
+compose file itself is already in the repo):
+
+Create `.env.e2e` directly (no example template exists; mirror the structure of
+`.env.prod`). It must define at minimum:
+
+```
+POSTGRES_PASSWORD=<strong-random-password>
+SECRET_KEY=<strong-random-secret>
+VPT_E2E_BACKEND_TOKEN=<shared-secret-matching-the-GitHub-repo-secret>
+E2E_ALLOWED_EMAILS=e2e@vpt.test
+```
+
+`.env.e2e` is gitignored — do not commit it.
+
+Then bring up the stack:
+
+```bash
+docker compose --env-file .env.e2e -f infra/docker-compose.e2e.yml up -d
+docker compose --env-file .env.e2e -f infra/docker-compose.e2e.yml \
+  run --rm --entrypoint sh api -c 'cd /app && alembic upgrade head'
+```
+
+Refresh the stack to a new image alongside prod deploys by pinning `IMAGE_TAG`
+and re-running `up -d`.
+
+**The `POST /v1/e2e/mint-token` endpoint is owned by P5.** It lives in
+`apps/api/**`, is gated on `E2E_MODE=1` so it never exists in prod, and is
+authenticated via the `X-E2E-Token` header checked against
+`VPT_E2E_BACKEND_TOKEN`. It mints a fixed configured user (`e2e@vpt.test`),
+ignores any request body, and returns `{ access_token, user }`. P4 owns the
+compose file + the workflow that calls it; the endpoint implementation is P5's.
+
+**Dependency on P5:** the minted token is attached as `Authorization: Bearer`,
+which authenticates only once P5's Bearer-header support lands in
+`get_current_user`. Until then the e2e read/write flows 401 (the sign-in bypass
+still passes — it loads the baked session without validating it).

--- a/docs/mobile-cicd.md
+++ b/docs/mobile-cicd.md
@@ -129,7 +129,7 @@ Create `.env.e2e` directly (no example template exists; mirror the structure of
 POSTGRES_PASSWORD=<strong-random-password>
 SECRET_KEY=<strong-random-secret>
 VPT_E2E_BACKEND_TOKEN=<shared-secret-matching-the-GitHub-repo-secret>
-E2E_ALLOWED_EMAILS=e2e@vpt.test
+AUTH_ALLOWED_EMAILS=e2e@vpt.test
 ```
 
 `.env.e2e` is gitignored — do not commit it.

--- a/infra/docker-compose.e2e.yml
+++ b/infra/docker-compose.e2e.yml
@@ -8,7 +8,8 @@
 #
 # Brought up once on the prod box by the operator (see docs/mobile-cicd.md
 # § "VPT e2e backend stack"):
-#   cp .env.e2e.example .env.e2e   # then fill in secrets
+#   # create infra/.env.e2e (mirror .env.prod) with POSTGRES_PASSWORD, SECRET_KEY,
+#   #   VPT_E2E_BACKEND_TOKEN, AUTH_ALLOWED_EMAILS=e2e@vpt.test
 #   docker compose --env-file .env.e2e -f infra/docker-compose.e2e.yml up -d
 #   docker compose --env-file .env.e2e -f infra/docker-compose.e2e.yml \
 #     run --rm --entrypoint sh api -c 'cd /app && alembic upgrade head'

--- a/infra/docker-compose.e2e.yml
+++ b/infra/docker-compose.e2e.yml
@@ -1,0 +1,145 @@
+# Isolated end-to-end stack for the mobile Maestro pipeline.
+#
+# Runs alongside the dev and prod stacks on the same host without colliding:
+# distinct project name (vpt-e2e), distinct ports, distinct named volumes,
+# distinct database. The mobile e2e emulator (.github/workflows/mobile-e2e.yml)
+# reaches this stack's api at http://10.0.2.2:8010 (the AVD host alias for the
+# runner's loopback). All published ports bind to loopback only.
+#
+# Brought up once on the prod box by the operator (see docs/mobile-cicd.md
+# § "VPT e2e backend stack"):
+#   cp .env.e2e.example .env.e2e   # then fill in secrets
+#   docker compose --env-file .env.e2e -f infra/docker-compose.e2e.yml up -d
+#   docker compose --env-file .env.e2e -f infra/docker-compose.e2e.yml \
+#     run --rm --entrypoint sh api -c 'cd /app && alembic upgrade head'
+#
+# Image tag is selected by IMAGE_TAG (defaults to latest); the operator pins it
+# to the deployed commit SHA when refreshing the stack alongside a prod deploy.
+
+name: vpt-e2e
+
+x-logging: &default-logging
+  driver: json-file
+  options:
+    max-size: "10m"
+    max-file: "5"
+
+services:
+  db:
+    image: postgres:15-alpine
+    container_name: vpt-e2e-db
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}
+      POSTGRES_DB: vacation_tracker_e2e
+    ports:
+      - "127.0.0.1:5437:5432"
+    volumes:
+      - vpt_e2e_postgres_data:/var/lib/postgresql/data
+    logging: *default-logging
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres -d vacation_tracker_e2e"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  redis:
+    image: redis:7-alpine
+    container_name: vpt-e2e-redis
+    restart: unless-stopped
+    ports:
+      - "127.0.0.1:6382:6379"
+    volumes:
+      - vpt_e2e_redis_data:/data
+    logging: *default-logging
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  temporal:
+    image: temporalio/auto-setup:latest
+    container_name: vpt-e2e-temporal
+    restart: unless-stopped
+    environment:
+      DB: postgres12
+      DB_PORT: 5432
+      POSTGRES_USER: postgres
+      POSTGRES_PWD: ${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}
+      POSTGRES_SEEDS: db
+    ports:
+      - "127.0.0.1:7236:7233"
+    depends_on:
+      db:
+        condition: service_healthy
+    logging: *default-logging
+    healthcheck:
+      test: ["CMD", "tctl", "--address", "temporal:7233", "cluster", "health"]
+      interval: 30s
+      timeout: 10s
+      retries: 10
+      start_period: 40s
+
+  api:
+    image: ghcr.io/ethanasm/vpt-api:${IMAGE_TAG:-latest}
+    container_name: vpt-e2e-api
+    restart: unless-stopped
+    env_file: ../.env.e2e
+    environment:
+      DATABASE_URL: ${DATABASE_URL:-postgresql+asyncpg://postgres:${POSTGRES_PASSWORD}@db:5432/vacation_tracker_e2e}
+      REDIS_URL: ${REDIS_URL:-redis://redis:6379/0}
+      TEMPORAL_ADDRESS: ${TEMPORAL_ADDRESS:-temporal:7233}
+      TEMPORAL_NAMESPACE: default
+      ENVIRONMENT: e2e
+      # E2E_MODE=1 is what gates P5's POST /v1/e2e/mint-token endpoint on (it
+      # never exists in prod, where E2E_MODE is unset). VPT_E2E_BACKEND_TOKEN is
+      # the shared secret the endpoint checks against the X-E2E-Token header
+      # (also the mobile-e2e.yml workflow secret).
+      E2E_MODE: "1"
+      VPT_E2E_BACKEND_TOKEN: ${VPT_E2E_BACKEND_TOKEN:?VPT_E2E_BACKEND_TOKEN is required}
+      # Don't call the live Skiplagged provider during create-trip.
+      MOCK_SKIPLAGGED_API: "true"
+    ports:
+      # The emulator reaches this at http://10.0.2.2:8010.
+      - "127.0.0.1:8010:8000"
+    depends_on:
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      temporal:
+        condition: service_healthy
+    logging: *default-logging
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fsS http://localhost:8000/ready || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 30s
+
+  worker:
+    image: ghcr.io/ethanasm/vpt-worker:${IMAGE_TAG:-latest}
+    container_name: vpt-e2e-worker
+    restart: unless-stopped
+    env_file: ../.env.e2e
+    environment:
+      DATABASE_URL: ${DATABASE_URL:-postgresql+asyncpg://postgres:${POSTGRES_PASSWORD}@db:5432/vacation_tracker_e2e}
+      REDIS_URL: ${REDIS_URL:-redis://redis:6379/0}
+      TEMPORAL_ADDRESS: ${TEMPORAL_ADDRESS:-temporal:7233}
+      TEMPORAL_NAMESPACE: default
+      TEMPORAL_TASK_QUEUE: ${TEMPORAL_TASK_QUEUE:-vacation-price-tracker-tasks}
+      MOCK_SKIPLAGGED_API: "true"
+    depends_on:
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      temporal:
+        condition: service_healthy
+    logging: *default-logging
+
+volumes:
+  vpt_e2e_postgres_data:
+  vpt_e2e_redis_data:

--- a/scripts/__tests__/bump-mobile-version.test.mjs
+++ b/scripts/__tests__/bump-mobile-version.test.mjs
@@ -1,0 +1,78 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, writeFileSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const SCRIPT = join(dirname(fileURLToPath(import.meta.url)), '..', 'bump-mobile-version.mjs');
+
+function withConfig(version, run) {
+  const dir = mkdtempSync(join(tmpdir(), 'bump-'));
+  const path = join(dir, 'app.config.ts');
+  writeFileSync(path, `const config = {\n  name: 'Price Tracker',\n  version: '${version}',\n};\nexport default config;\n`);
+  try {
+    return run(path, dir);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+function bump(path, args) {
+  return execFileSync('node', [SCRIPT, ...args], {
+    encoding: 'utf8',
+    env: { ...process.env, BUMP_MOBILE_CONFIG_PATH: path },
+  }).trim();
+}
+
+test('--print returns the current version without writing', () => {
+  withConfig('0.3.2', (path) => {
+    assert.equal(bump(path, ['--print']), '0.3.2');
+    assert.match(readFileSync(path, 'utf8'), /version: '0\.3\.2'/);
+  });
+});
+
+test('patch bump increments the patch component', () => {
+  withConfig('0.3.2', (path) => {
+    assert.equal(bump(path, ['--type', 'patch']), '0.3.3');
+    assert.match(readFileSync(path, 'utf8'), /version: '0\.3\.3'/);
+  });
+});
+
+test('minor bump increments minor and zeroes patch', () => {
+  withConfig('0.3.2', (path) => {
+    assert.equal(bump(path, ['--type', 'minor']), '0.4.0');
+  });
+});
+
+test('major bump maps to minor while pre-1.0', () => {
+  withConfig('0.3.2', (path) => {
+    assert.equal(bump(path, ['--type', 'major']), '0.4.0');
+  });
+});
+
+test('major bump increments major once at or above 1.0', () => {
+  withConfig('1.4.2', (path) => {
+    assert.equal(bump(path, ['--type', 'major']), '2.0.0');
+  });
+});
+
+test('--floor raises the base when the tag is ahead of the file', () => {
+  withConfig('0.3.2', (path) => {
+    // file says 0.3.2 but the last tag was 0.5.0 → patch off the floor → 0.5.1
+    assert.equal(bump(path, ['--type', 'patch', '--floor', '0.5.0']), '0.5.1');
+  });
+});
+
+test('--floor below the file version is ignored', () => {
+  withConfig('0.3.2', (path) => {
+    assert.equal(bump(path, ['--type', 'patch', '--floor', '0.1.0']), '0.3.3');
+  });
+});
+
+test('rejects an invalid --type', () => {
+  withConfig('0.3.2', (path) => {
+    assert.throws(() => bump(path, ['--type', 'bogus']));
+  });
+});

--- a/scripts/__tests__/bump-mobile-version.test.mjs
+++ b/scripts/__tests__/bump-mobile-version.test.mjs
@@ -1,78 +1,85 @@
-import { test } from 'node:test';
-import assert from 'node:assert/strict';
-import { execFileSync } from 'node:child_process';
-import { mkdtempSync, writeFileSync, readFileSync, rmSync } from 'node:fs';
-import { tmpdir } from 'node:os';
-import { join, dirname } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
 
-const SCRIPT = join(dirname(fileURLToPath(import.meta.url)), '..', 'bump-mobile-version.mjs');
+const SCRIPT = join(
+	dirname(fileURLToPath(import.meta.url)),
+	"..",
+	"bump-mobile-version.mjs",
+);
 
 function withConfig(version, run) {
-  const dir = mkdtempSync(join(tmpdir(), 'bump-'));
-  const path = join(dir, 'app.config.ts');
-  writeFileSync(path, `const config = {\n  name: 'Price Tracker',\n  version: '${version}',\n};\nexport default config;\n`);
-  try {
-    return run(path, dir);
-  } finally {
-    rmSync(dir, { recursive: true, force: true });
-  }
+	const dir = mkdtempSync(join(tmpdir(), "bump-"));
+	const path = join(dir, "app.config.ts");
+	writeFileSync(
+		path,
+		`const config = {\n  name: 'Price Tracker',\n  version: '${version}',\n};\nexport default config;\n`,
+	);
+	try {
+		return run(path, dir);
+	} finally {
+		rmSync(dir, { recursive: true, force: true });
+	}
 }
 
 function bump(path, args) {
-  return execFileSync('node', [SCRIPT, ...args], {
-    encoding: 'utf8',
-    env: { ...process.env, BUMP_MOBILE_CONFIG_PATH: path },
-  }).trim();
+	return execFileSync("node", [SCRIPT, ...args], {
+		encoding: "utf8",
+		env: { ...process.env, BUMP_MOBILE_CONFIG_PATH: path },
+	}).trim();
 }
 
-test('--print returns the current version without writing', () => {
-  withConfig('0.3.2', (path) => {
-    assert.equal(bump(path, ['--print']), '0.3.2');
-    assert.match(readFileSync(path, 'utf8'), /version: '0\.3\.2'/);
-  });
+test("--print returns the current version without writing", () => {
+	withConfig("0.3.2", (path) => {
+		assert.equal(bump(path, ["--print"]), "0.3.2");
+		assert.match(readFileSync(path, "utf8"), /version: '0\.3\.2'/);
+	});
 });
 
-test('patch bump increments the patch component', () => {
-  withConfig('0.3.2', (path) => {
-    assert.equal(bump(path, ['--type', 'patch']), '0.3.3');
-    assert.match(readFileSync(path, 'utf8'), /version: '0\.3\.3'/);
-  });
+test("patch bump increments the patch component", () => {
+	withConfig("0.3.2", (path) => {
+		assert.equal(bump(path, ["--type", "patch"]), "0.3.3");
+		assert.match(readFileSync(path, "utf8"), /version: '0\.3\.3'/);
+	});
 });
 
-test('minor bump increments minor and zeroes patch', () => {
-  withConfig('0.3.2', (path) => {
-    assert.equal(bump(path, ['--type', 'minor']), '0.4.0');
-  });
+test("minor bump increments minor and zeroes patch", () => {
+	withConfig("0.3.2", (path) => {
+		assert.equal(bump(path, ["--type", "minor"]), "0.4.0");
+	});
 });
 
-test('major bump maps to minor while pre-1.0', () => {
-  withConfig('0.3.2', (path) => {
-    assert.equal(bump(path, ['--type', 'major']), '0.4.0');
-  });
+test("major bump maps to minor while pre-1.0", () => {
+	withConfig("0.3.2", (path) => {
+		assert.equal(bump(path, ["--type", "major"]), "0.4.0");
+	});
 });
 
-test('major bump increments major once at or above 1.0', () => {
-  withConfig('1.4.2', (path) => {
-    assert.equal(bump(path, ['--type', 'major']), '2.0.0');
-  });
+test("major bump increments major once at or above 1.0", () => {
+	withConfig("1.4.2", (path) => {
+		assert.equal(bump(path, ["--type", "major"]), "2.0.0");
+	});
 });
 
-test('--floor raises the base when the tag is ahead of the file', () => {
-  withConfig('0.3.2', (path) => {
-    // file says 0.3.2 but the last tag was 0.5.0 → patch off the floor → 0.5.1
-    assert.equal(bump(path, ['--type', 'patch', '--floor', '0.5.0']), '0.5.1');
-  });
+test("--floor raises the base when the tag is ahead of the file", () => {
+	withConfig("0.3.2", (path) => {
+		// file says 0.3.2 but the last tag was 0.5.0 → patch off the floor → 0.5.1
+		assert.equal(bump(path, ["--type", "patch", "--floor", "0.5.0"]), "0.5.1");
+	});
 });
 
-test('--floor below the file version is ignored', () => {
-  withConfig('0.3.2', (path) => {
-    assert.equal(bump(path, ['--type', 'patch', '--floor', '0.1.0']), '0.3.3');
-  });
+test("--floor below the file version is ignored", () => {
+	withConfig("0.3.2", (path) => {
+		assert.equal(bump(path, ["--type", "patch", "--floor", "0.1.0"]), "0.3.3");
+	});
 });
 
-test('rejects an invalid --type', () => {
-  withConfig('0.3.2', (path) => {
-    assert.throws(() => bump(path, ['--type', 'bogus']));
-  });
+test("rejects an invalid --type", () => {
+	withConfig("0.3.2", (path) => {
+		assert.throws(() => bump(path, ["--type", "bogus"]));
+	});
 });

--- a/scripts/__tests__/bump-mobile-version.test.mjs
+++ b/scripts/__tests__/bump-mobile-version.test.mjs
@@ -12,12 +12,13 @@ const SCRIPT = join(
 	"bump-mobile-version.mjs",
 );
 
-function withConfig(version, run) {
+function withConfig(version, run, { quotes = "double" } = {}) {
 	const dir = mkdtempSync(join(tmpdir(), "bump-"));
 	const path = join(dir, "app.config.ts");
+	const q = quotes === "single" ? "'" : '"';
 	writeFileSync(
 		path,
-		`const config = {\n  name: 'Price Tracker',\n  version: '${version}',\n};\nexport default config;\n`,
+		`const config = {\n  name: ${q}Price Tracker${q},\n  version: ${q}${version}${q},\n};\nexport default config;\n`,
 	);
 	try {
 		return run(path, dir);
@@ -33,18 +34,27 @@ function bump(path, args) {
 	}).trim();
 }
 
-test("--print returns the current version without writing", () => {
+test("--print returns the current version without writing (double quotes)", () => {
 	withConfig("0.3.2", (path) => {
 		assert.equal(bump(path, ["--print"]), "0.3.2");
-		assert.match(readFileSync(path, "utf8"), /version: '0\.3\.2'/);
+		assert.match(readFileSync(path, "utf8"), /version: "0\.3\.2"/);
 	});
 });
 
-test("patch bump increments the patch component", () => {
+test("patch bump increments the patch component (double quotes)", () => {
 	withConfig("0.3.2", (path) => {
 		assert.equal(bump(path, ["--type", "patch"]), "0.3.3");
-		assert.match(readFileSync(path, "utf8"), /version: '0\.3\.3'/);
+		assert.match(readFileSync(path, "utf8"), /version: "0\.3\.3"/);
 	});
+});
+
+test("--print and patch bump work with single-quote fixture (quote-agnostic)", () => {
+	withConfig("0.3.2", (path) => {
+		assert.equal(bump(path, ["--print"]), "0.3.2");
+		assert.match(readFileSync(path, "utf8"), /version: '0\.3\.2'/);
+		assert.equal(bump(path, ["--type", "patch"]), "0.3.3");
+		assert.match(readFileSync(path, "utf8"), /version: '0\.3\.3'/);
+	}, { quotes: "single" });
 });
 
 test("minor bump increments minor and zeroes patch", () => {

--- a/scripts/bump-mobile-version.mjs
+++ b/scripts/bump-mobile-version.mjs
@@ -32,8 +32,8 @@ const CONFIG_PATH =
 		"apps/mobile/app.config.ts",
 	);
 
-// Matches exactly the `version: '0.1.0',` line in the ExpoConfig literal.
-const VERSION_RE = /(\n\s*version:\s*')(\d+\.\d+\.\d+)(',)/g;
+// Matches the `version: '0.1.0',` or `version: "0.1.0",` line in the ExpoConfig literal.
+const VERSION_RE = /(\n\s*version:\s*["'])(\d+\.\d+\.\d+)(["'],)/g;
 
 function fail(msg) {
 	console.error(`[bump-mobile-version] ${msg}`);

--- a/scripts/bump-mobile-version.mjs
+++ b/scripts/bump-mobile-version.mjs
@@ -1,0 +1,101 @@
+#!/usr/bin/env node
+// Bumps the mobile app version in apps/mobile/app.config.ts — the single
+// source of truth for the user-facing version AND the expo-updates runtime
+// (`runtimeVersion: { policy: 'appVersion' }`). Mirrors showbook's
+// scripts/bump-mobile-version.mjs; see the Aurora index "Versioning"
+// constraint for the scheme.
+//
+//   node scripts/bump-mobile-version.mjs --type patch|minor|major [--floor X.Y.Z]
+//   node scripts/bump-mobile-version.mjs --print
+//
+// --type:  the bump to apply. While the major version is 0 (the beta line),
+//          `major` is mapped to `minor` — the 1.0.0 jump is a deliberate
+//          manual act, never automated.
+// --floor: base the bump on max(file version, floor). The deploy workflow
+//          passes the highest `mobile-v*` tag here so a queued run whose
+//          checkout predates the previous run's bump commit can't re-issue an
+//          already-used version.
+// --print: print the current file version and exit without writing.
+//
+// Prints the resulting version to stdout (and nothing else), so callers can do
+// NEW=$(node scripts/bump-mobile-version.mjs --type patch).
+
+import { readFileSync, writeFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const CONFIG_PATH =
+  process.env.BUMP_MOBILE_CONFIG_PATH ||
+  path.join(
+    path.dirname(fileURLToPath(import.meta.url)),
+    '..',
+    'apps/mobile/app.config.ts',
+  );
+
+// Matches exactly the `version: '0.1.0',` line in the ExpoConfig literal.
+const VERSION_RE = /(\n\s*version:\s*')(\d+\.\d+\.\d+)(',)/g;
+
+function fail(msg) {
+  console.error(`[bump-mobile-version] ${msg}`);
+  process.exit(1);
+}
+
+function parseVersion(s) {
+  const m = /^(\d+)\.(\d+)\.(\d+)$/.exec(s);
+  if (!m) fail(`not a MAJOR.MINOR.PATCH version: '${s}'`);
+  return m.slice(1).map(Number);
+}
+
+function compareVersions(a, b) {
+  for (let i = 0; i < 3; i++) {
+    if (a[i] !== b[i]) return a[i] - b[i];
+  }
+  return 0;
+}
+
+const args = process.argv.slice(2);
+function flagValue(name) {
+  const i = args.indexOf(name);
+  return i === -1 ? undefined : args[i + 1];
+}
+
+const source = readFileSync(CONFIG_PATH, 'utf8');
+const matches = [...source.matchAll(VERSION_RE)];
+if (matches.length !== 1) {
+  fail(
+    `expected exactly one version line in ${CONFIG_PATH}, found ${matches.length} — ` +
+      `update VERSION_RE if the config format changed`,
+  );
+}
+const current = parseVersion(matches[0][2]);
+
+if (args.includes('--print')) {
+  console.log(current.join('.'));
+  process.exit(0);
+}
+
+const type = flagValue('--type');
+if (!['patch', 'minor', 'major'].includes(type ?? '')) {
+  fail(`--type must be patch, minor, or major (got '${type}')`);
+}
+
+const floorArg = flagValue('--floor');
+let base = current;
+if (floorArg) {
+  const floor = parseVersion(floorArg);
+  if (compareVersions(floor, base) > 0) base = floor;
+}
+
+// Pre-1.0 (beta line): breaking changes bump minor, not major.
+const effectiveType = type === 'major' && base[0] === 0 ? 'minor' : type;
+
+const next =
+  effectiveType === 'major'
+    ? [base[0] + 1, 0, 0]
+    : effectiveType === 'minor'
+      ? [base[0], base[1] + 1, 0]
+      : [base[0], base[1], base[2] + 1];
+
+const nextStr = next.join('.');
+writeFileSync(CONFIG_PATH, source.replace(VERSION_RE, `$1${nextStr}$3`), 'utf8');
+console.log(nextStr);

--- a/scripts/bump-mobile-version.mjs
+++ b/scripts/bump-mobile-version.mjs
@@ -20,82 +20,85 @@
 // Prints the resulting version to stdout (and nothing else), so callers can do
 // NEW=$(node scripts/bump-mobile-version.mjs --type patch).
 
-import { readFileSync, writeFileSync } from 'node:fs';
-import { fileURLToPath } from 'node:url';
-import path from 'node:path';
+import { readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 
 const CONFIG_PATH =
-  process.env.BUMP_MOBILE_CONFIG_PATH ||
-  path.join(
-    path.dirname(fileURLToPath(import.meta.url)),
-    '..',
-    'apps/mobile/app.config.ts',
-  );
+	process.env.BUMP_MOBILE_CONFIG_PATH ||
+	path.join(
+		path.dirname(fileURLToPath(import.meta.url)),
+		"..",
+		"apps/mobile/app.config.ts",
+	);
 
 // Matches exactly the `version: '0.1.0',` line in the ExpoConfig literal.
 const VERSION_RE = /(\n\s*version:\s*')(\d+\.\d+\.\d+)(',)/g;
 
 function fail(msg) {
-  console.error(`[bump-mobile-version] ${msg}`);
-  process.exit(1);
+	console.error(`[bump-mobile-version] ${msg}`);
+	process.exit(1);
 }
 
 function parseVersion(s) {
-  const m = /^(\d+)\.(\d+)\.(\d+)$/.exec(s);
-  if (!m) fail(`not a MAJOR.MINOR.PATCH version: '${s}'`);
-  return m.slice(1).map(Number);
+	const m = /^(\d+)\.(\d+)\.(\d+)$/.exec(s);
+	if (!m) fail(`not a MAJOR.MINOR.PATCH version: '${s}'`);
+	return m.slice(1).map(Number);
 }
 
 function compareVersions(a, b) {
-  for (let i = 0; i < 3; i++) {
-    if (a[i] !== b[i]) return a[i] - b[i];
-  }
-  return 0;
+	for (let i = 0; i < 3; i++) {
+		if (a[i] !== b[i]) return a[i] - b[i];
+	}
+	return 0;
 }
 
 const args = process.argv.slice(2);
 function flagValue(name) {
-  const i = args.indexOf(name);
-  return i === -1 ? undefined : args[i + 1];
+	const i = args.indexOf(name);
+	return i === -1 ? undefined : args[i + 1];
 }
 
-const source = readFileSync(CONFIG_PATH, 'utf8');
+const source = readFileSync(CONFIG_PATH, "utf8");
 const matches = [...source.matchAll(VERSION_RE)];
 if (matches.length !== 1) {
-  fail(
-    `expected exactly one version line in ${CONFIG_PATH}, found ${matches.length} — ` +
-      `update VERSION_RE if the config format changed`,
-  );
+	fail(
+		`expected exactly one version line in ${CONFIG_PATH}, found ${matches.length} — update VERSION_RE if the config format changed`,
+	);
 }
 const current = parseVersion(matches[0][2]);
 
-if (args.includes('--print')) {
-  console.log(current.join('.'));
-  process.exit(0);
+if (args.includes("--print")) {
+	console.log(current.join("."));
+	process.exit(0);
 }
 
-const type = flagValue('--type');
-if (!['patch', 'minor', 'major'].includes(type ?? '')) {
-  fail(`--type must be patch, minor, or major (got '${type}')`);
+const type = flagValue("--type");
+if (!["patch", "minor", "major"].includes(type ?? "")) {
+	fail(`--type must be patch, minor, or major (got '${type}')`);
 }
 
-const floorArg = flagValue('--floor');
+const floorArg = flagValue("--floor");
 let base = current;
 if (floorArg) {
-  const floor = parseVersion(floorArg);
-  if (compareVersions(floor, base) > 0) base = floor;
+	const floor = parseVersion(floorArg);
+	if (compareVersions(floor, base) > 0) base = floor;
 }
 
 // Pre-1.0 (beta line): breaking changes bump minor, not major.
-const effectiveType = type === 'major' && base[0] === 0 ? 'minor' : type;
+const effectiveType = type === "major" && base[0] === 0 ? "minor" : type;
 
 const next =
-  effectiveType === 'major'
-    ? [base[0] + 1, 0, 0]
-    : effectiveType === 'minor'
-      ? [base[0], base[1] + 1, 0]
-      : [base[0], base[1], base[2] + 1];
+	effectiveType === "major"
+		? [base[0] + 1, 0, 0]
+		: effectiveType === "minor"
+			? [base[0], base[1] + 1, 0]
+			: [base[0], base[1], base[2] + 1];
 
-const nextStr = next.join('.');
-writeFileSync(CONFIG_PATH, source.replace(VERSION_RE, `$1${nextStr}$3`), 'utf8');
+const nextStr = next.join(".");
+writeFileSync(
+	CONFIG_PATH,
+	source.replace(VERSION_RE, `$1${nextStr}$3`),
+	"utf8",
+);
 console.log(nextStr);

--- a/scripts/mobile-deploy-failure-email.sh
+++ b/scripts/mobile-deploy-failure-email.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# Emails the eas-cli error summary + a direct link to the EAS build page when a
+# mobile-deploy job fails, so the failure is actionable from the inbox without
+# digging through the Actions log to find the Expo link and then logging into
+# expo.dev. Invoked from the `if: failure()` steps in
+# .github/workflows/mobile-deploy.yml — the `ota` and `release` jobs share this
+# script so the notifier logic isn't duplicated across jobs.
+#
+# Best-effort by design: always exits 0 so the notifier's own errors can never
+# mask the real failure, and silently no-ops when the email secrets aren't set.
+#
+# Expected env (set by the workflow step):
+#   RESEND_API_KEY  — Resend API key
+#   EMAIL_FROM      — verified Resend sender
+#   ALERT_EMAILS    — comma-separated recipient list (ADMIN_EMAILS secret)
+#   RUN_URL         — link to the Actions run
+#   COMMIT_SHA      — the deployed commit
+#   TRIGGER         — github.event_name
+#   MODE            — update | build
+# Reads the combined eas-cli output from $GITHUB_WORKSPACE/eas-output.log.
+
+set +e  # never let the notifier's own errors mask the real failure
+LOG="$GITHUB_WORKSPACE/eas-output.log"
+
+if [ -z "${RESEND_API_KEY:-}" ] || [ -z "${EMAIL_FROM:-}" ] || [ -z "${ALERT_EMAILS:-}" ]; then
+  echo "::warning::Mobile-deploy failure email skipped — set RESEND_API_KEY, EMAIL_FROM and ADMIN_EMAILS secrets to enable it."
+  exit 0
+fi
+
+SHORT_SHA="${COMMIT_SHA:0:7}"
+SUBJECT="🔴 VPT mobile deploy failed — ${SHORT_SHA} (${TRIGGER}/${MODE})"
+
+BUILD_LINKS=""
+if [ -f "$LOG" ]; then
+  BUILD_LINKS=$(grep -oiE 'https://expo\.dev/[^ ]*builds/[a-z0-9-]+' "$LOG" | sort -u | head -5)
+fi
+
+if [ -f "$LOG" ]; then
+  LOG_TAIL=$(sed -E 's/\x1b\[[0-9;]*[A-Za-z]//g' "$LOG" \
+    | tr -d '\r' \
+    | tail -c 14000 \
+    | sed -e 's/&/\&amp;/g' -e 's/</\&lt;/g' -e 's/>/\&gt;/g')
+else
+  LOG_TAIL="(no eas-cli output captured — the deploy failed before any EAS command ran; see the Actions run)"
+fi
+
+if [ -n "$BUILD_LINKS" ]; then
+  BUILD_LINKS_HTML="<p><strong>EAS build page(s):</strong></p><ul>"
+  while IFS= read -r url; do
+    [ -n "$url" ] && BUILD_LINKS_HTML="${BUILD_LINKS_HTML}<li><a href=\"${url}\">${url}</a></li>"
+  done <<< "$BUILD_LINKS"
+  BUILD_LINKS_HTML="${BUILD_LINKS_HTML}</ul>"
+else
+  BUILD_LINKS_HTML="<p>No EAS build-page link found in the output (OTA update, or the failure happened before a build was queued).</p>"
+fi
+
+HTML="<h2>VPT mobile deploy failed</h2>
+<p><strong>Commit:</strong> ${SHORT_SHA}<br>
+<strong>Trigger:</strong> ${TRIGGER} / ${MODE}<br>
+<strong>Actions run:</strong> <a href=\"${RUN_URL}\">${RUN_URL}</a></p>
+${BUILD_LINKS_HTML}
+<p><strong>eas-cli output (tail):</strong></p>
+<pre style=\"background:#f6f8fa;padding:12px;border-radius:6px;overflow:auto;font-size:12px;line-height:1.4\">${LOG_TAIL}</pre>"
+
+TO_JSON=$(printf '%s' "$ALERT_EMAILS" \
+  | jq -R 'split(",") | map(gsub("^\\s+|\\s+$";"")) | map(select(length>0))')
+
+PAYLOAD=$(jq -n \
+  --arg from "$EMAIL_FROM" \
+  --argjson to "$TO_JSON" \
+  --arg subject "$SUBJECT" \
+  --arg html "$HTML" \
+  '{from:$from, to:$to, subject:$subject, html:$html}')
+
+RESP=$(curl -sS -X POST https://api.resend.com/emails \
+  -H "Authorization: Bearer $RESEND_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d "$PAYLOAD")
+echo "Resend response: $RESP"
+if printf '%s' "$RESP" | grep -q '"id"'; then
+  echo "Failure-notification email sent."
+else
+  echo "::warning::Resend did not return a message id — the email may not have been delivered. See the response above."
+fi
+exit 0

--- a/scripts/setup-runner-android.sh
+++ b/scripts/setup-runner-android.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# Idempotent one-time setup for Android e2e on the self-hosted vpt-prod runner.
+#
+# Run on the prod box AFTER the GitHub Actions runner itself is online (the same
+# runner deploy.yml uses, label vpt-prod). Installs Android command-line tools +
+# the packages Maestro/Gradle need and creates the AVD mobile-e2e.yml looks for.
+#
+# Re-running is safe — every step checks for the artifact it would create.
+
+set -euo pipefail
+
+ANDROID_SDK_ROOT="${ANDROID_SDK_ROOT:-/opt/android-sdk}"
+CMDLINE_TOOLS_VERSION="${CMDLINE_TOOLS_VERSION:-13114758}"
+SYSTEM_IMAGE="${SYSTEM_IMAGE:-system-images;android-34;google_apis;x86_64}"
+PLATFORM="${PLATFORM:-platforms;android-34}"
+# Match what Expo SDK 56's prebuild emits (apps/mobile/android/build.gradle ext
+# block). Keep in sync when bumping Expo.
+BUILD_TOOLS="${BUILD_TOOLS:-build-tools;36.0.0}"
+COMPILE_PLATFORM="${COMPILE_PLATFORM:-platforms;android-36}"
+NDK="${NDK:-ndk;27.1.12297006}"
+AVD_NAME="${AVD_NAME:-vpt_e2e}"
+
+GREEN='\033[0;32m'; YELLOW='\033[1;33m'; RED='\033[0;31m'; BOLD='\033[1m'; NC='\033[0m'
+info() { printf "${GREEN}✓${NC} %s\n" "$1"; }
+warn() { printf "${YELLOW}!${NC} %s\n" "$1"; }
+fail() { printf "${RED}✗${NC} %s\n" "$1"; exit 1; }
+step() { printf "\n${BOLD}%s${NC}\n" "$1"; }
+
+step "Checking prerequisites…"
+for cmd in curl unzip java; do
+  command -v "$cmd" &>/dev/null || fail "$cmd is required but not found"
+done
+JAVA_MAJOR=$(java -version 2>&1 | awk -F'"' '/version/ {split($2, a, "."); print (a[1]=="1") ? a[2] : a[1]}')
+if [ "$JAVA_MAJOR" -lt 17 ]; then
+  fail "Java 17+ required (found $JAVA_MAJOR). On Ubuntu: sudo apt-get install -y openjdk-17-jdk"
+fi
+info "java $JAVA_MAJOR, curl, unzip"
+
+step "Installing Android cmdline-tools at ${ANDROID_SDK_ROOT}…"
+CMDLINE_BIN="$ANDROID_SDK_ROOT/cmdline-tools/latest/bin"
+if [ -x "$CMDLINE_BIN/sdkmanager" ]; then
+  info "cmdline-tools already present"
+else
+  if [ ! -d "$ANDROID_SDK_ROOT" ]; then
+    sudo mkdir -p "$ANDROID_SDK_ROOT"
+    sudo chown "$USER" "$ANDROID_SDK_ROOT"
+  fi
+  TMP=$(mktemp -d); trap 'rm -rf "$TMP"' EXIT
+  ZIP="$TMP/cmdline-tools.zip"
+  URL="https://dl.google.com/android/repository/commandlinetools-linux-${CMDLINE_TOOLS_VERSION}_latest.zip"
+  echo "  Downloading $URL"
+  curl -sSL -o "$ZIP" "$URL"
+  unzip -q "$ZIP" -d "$TMP"
+  mkdir -p "$ANDROID_SDK_ROOT/cmdline-tools"
+  rm -rf "$ANDROID_SDK_ROOT/cmdline-tools/latest"
+  mv "$TMP/cmdline-tools" "$ANDROID_SDK_ROOT/cmdline-tools/latest"
+  info "Installed to $ANDROID_SDK_ROOT/cmdline-tools/latest"
+fi
+
+export ANDROID_SDK_ROOT
+export PATH="$CMDLINE_BIN:$ANDROID_SDK_ROOT/platform-tools:$ANDROID_SDK_ROOT/emulator:$PATH"
+
+step "Installing SDK packages…"
+yes | sdkmanager --licenses >/dev/null
+sdkmanager --install \
+  "platform-tools" \
+  "emulator" \
+  "$PLATFORM" \
+  "$COMPILE_PLATFORM" \
+  "$BUILD_TOOLS" \
+  "$NDK" \
+  "$SYSTEM_IMAGE" >/dev/null
+info "SDK packages installed"
+
+step "Creating AVD '$AVD_NAME'…"
+if avdmanager list avd 2>/dev/null | grep -q "Name: ${AVD_NAME}\$"; then
+  info "AVD already exists"
+else
+  echo "no" | avdmanager create avd \
+    --name "$AVD_NAME" \
+    --package "$SYSTEM_IMAGE" \
+    --device "pixel_6" \
+    --force
+  CFG="$HOME/.android/avd/${AVD_NAME}.avd/config.ini"
+  if [ -f "$CFG" ]; then
+    {
+      echo "hw.ramSize=2048"
+      echo "vm.heapSize=512"
+      echo "disk.dataPartition.size=4096M"
+      echo "hw.gpu.enabled=yes"
+      echo "hw.gpu.mode=swiftshader_indirect"
+    } >> "$CFG"
+  fi
+  info "AVD '$AVD_NAME' created (Pixel 6, $SYSTEM_IMAGE)"
+fi
+
+step "Checking KVM acceleration…"
+if [ -e /dev/kvm ] && [ -r /dev/kvm ] && [ -w /dev/kvm ]; then
+  info "/dev/kvm accessible — emulator boots hardware-accelerated"
+else
+  warn "/dev/kvm not accessible — emulator falls back to software rendering (slow)."
+  warn "On WSL2: enable nestedVirtualization=true in .wslconfig and 'sudo usermod -aG kvm \$USER'."
+fi
+
+step "Installing Maestro CLI (idempotent)…"
+if command -v maestro >/dev/null 2>&1; then
+  info "Maestro already on PATH ($(maestro --version 2>&1 | head -1))"
+else
+  curl -fsSL "https://get.maestro.mobile.dev" | bash
+  info "Maestro installed at \$HOME/.maestro"
+  warn "Add 'export PATH=\"\$HOME/.maestro/bin:\$PATH\"' to your shell rc"
+fi
+
+printf "\n${BOLD}══════════════════════════════════════${NC}\n"
+printf "${BOLD}  Android e2e tooling ready (VPT)${NC}\n"
+printf "${BOLD}══════════════════════════════════════${NC}\n\n"
+printf "  SDK:    %s\n" "$ANDROID_SDK_ROOT"
+printf "  AVD:    %s\n" "$AVD_NAME"
+printf "  System: %s\n\n" "$SYSTEM_IMAGE"
+printf "  Repo variable to set (Settings → Variables):\n"
+printf "    ANDROID_SDK_ROOT = %s\n\n" "$ANDROID_SDK_ROOT"


### PR DESCRIPTION
## Summary

Stands up the mobile CI/CD + e2e pipeline for `apps/mobile` (plan **P4** of the Aurora effort), faithfully mirrored from the `showbook` repo and adapted to VPT's names/toolchain. Two GitHub Actions workflows plus the supporting EAS config, version-bump tooling, Maestro e2e flows, an isolated e2e backend stack, and an operator runbook.

- **`mobile-deploy.yml`** — continuous OTA to the `preview` channel on JS-only merges; an **approval-gated** store-release path (`environment: mobile-release`) that bumps the version, builds `--profile preview-store`, and `eas submit`s to **Play internal + TestFlight** after a human approves. Triggered off `Build Prod Images` completing on `main`.
- **`mobile-e2e.yml`** — self-hosted (`vpt-prod`) Android emulator + Maestro run: local APK build, e2e bearer minted from an isolated backend, flows executed, screenshots published to `pr-screenshots` on failure. PR-gated behind the `mobile-visual` label.
- **EAS profiles** (`apps/mobile/eas.json`): adds `preview-store` (store AAB, autoIncrement) and `e2e` (`EXPO_PUBLIC_E2E_MODE=1`) profiles + the Play/ASC submit profiles, on top of P2's existing confirmed `base` profile. `app.config.ts` gains the EAS Update URL and an e2e-only Android cleartext toggle.
- **`scripts/bump-mobile-version.mjs`** (+ 8 unit tests): conventional-commit version bump with pre-1.0 `major→minor` mapping and a `--floor` guard for queued runs.
- **Maestro e2e** (`apps/mobile/e2e/**`): sign-in / trips-list / trip-detail / create-trip flows + a YAML dry-run validator.
- **`infra/docker-compose.e2e.yml`**: isolated `vpt-e2e` API+DB(+redis+temporal) stack (distinct project/ports/db/volumes; loopback-bound; `E2E_MODE=1`, `MOCK_SKIPLAGGED_API=true`).
- **`docs/mobile-cicd.md`** + **`scripts/setup-runner-android.sh`**: the one-time operator runbook + idempotent Android-runner provisioning.

### Adaptation note (plan vs. repo reality)
The P4 plan was written assuming it would *create* `eas.json`/`app.config.ts` from scratch with placeholders and bundle id `me.ethanasm.vpt`. P2 had already merged a **real, confirmed** `eas.json` (real prod domain + Google OAuth client IDs, `appVersionSource: local`) and `app.config.ts` (real EAS `projectId`, bundle ids `me.ethanasm.vacation_price_tracker` / `me.ethanasm.vacation-price-tracker`). Per an explicit decision, this PR **adapts to the real foundation** — it preserves the confirmed values and the real bundle ids everywhere (Maestro `appId`, adb commands), and only *adds* the missing P4 pieces. No `CONFIRM-*` placeholders remain.

## Cross-plan dependency (scoped work — read before reacting to a red e2e run)
`mobile-e2e.yml` is **intentionally dormant** until **P3 (mobile-screens)** lands: it taps testIDs (`sign-in-google-button`, `trip-card`, `new-trip-fab`, …) and relies on the `EXPO_PUBLIC_E2E_MODE` auth-bypass that P3's screens provide. P5 (#32, merged) supplies the Bearer-header `get_current_user` + `POST /v1/e2e/mint-token` backend. Until P3 merges, an authenticated e2e run will 401/empty-list — **expected, not a regression**. The `mobile-visual` label gate keeps it from blocking unrelated PRs. The deploy pipeline (OTA / build / submit) is fully independent and works standalone today.

`apps/mobile/package.json` was deliberately **not** edited (the optional e2e convenience scripts were skipped) to guarantee zero merge conflict with P3, which owns `package.json` appends. The workflow invokes the validator via `node e2e/scripts/dry-run.mjs` directly, so nothing depends on those scripts.

## Operator / Deployment Steps

**This is the bootstrap of the mobile pipeline — nothing runs until the human provisions the items below.** Full runbook: `docs/mobile-cicd.md`.

### New GitHub repo secrets (Settings → Secrets → Actions)
| Secret | Where | Req? | Used by |
|---|---|---|---|
| `EXPO_TOKEN` | GitHub secret | required | both workflows (EAS update/build/submit) |
| `PLAY_SERVICE_ACCOUNT_JSON` | GitHub secret | required (Android submit) | mobile-deploy |
| `ASC_API_KEY_P8` / `ASC_API_KEY_ID` / `ASC_API_KEY_ISSUER_ID` / `ASC_APP_ID` | GitHub secret | required (iOS submit) | mobile-deploy |
| `RELEASE_DEPLOY_KEY` (preferred) **or** `RELEASE_PUSH_TOKEN` | GitHub secret | required (version-bump pushback) | mobile-deploy |
| `VPT_E2E_BACKEND_TOKEN` | GitHub secret **and** `.env.e2e` on the prod box | required (e2e mint) | mobile-e2e + e2e stack |
| `RESEND_API_KEY` / `EMAIL_FROM` / `ADMIN_EMAILS` | GitHub secret | optional (failure email) | mobile-deploy |

### New env vars
- `.env.e2e` (operator-managed on the prod box, now gitignored): `POSTGRES_PASSWORD`, `SECRET_KEY`, `VPT_E2E_BACKEND_TOKEN`, sign-in allowlist pinned to `e2e@vpt.test`. Mirrors `.env.prod`.
- `EXPO_PUBLIC_*` values (prod domain + Google OAuth client IDs) are already real in `eas.json`; the OTA step mirrors them — keep the two in sync if ever rotated.

### New GitHub variables (optional)
- `ANDROID_SDK_ROOT` (default `/opt/android-sdk`), `ANDROID_AVD_HOME`, `ANDROID_AVD_SYSTEM_IMAGE` — for the self-hosted Android runner.

### One-time infra / runner / credential provisioning
1. **EAS:** project already linked (`projectId` in `app.config.ts`); generate `EXPO_TOKEN`; run the one-time interactive iOS credential generation. (`eas init` NOT needed.)
2. **Arm the release gate:** Settings → Environments → `mobile-release` → add a Required reviewer (it's **fail-open until armed**).
3. **Branch ruleset bypass** for the version-bump push (deploy key in the bypass list, or a bypass-listed PAT).
4. **Android runner:** run `scripts/setup-runner-android.sh` once on the `vpt-prod` box (SDK + `vpt_e2e` AVD + Maestro).
5. **e2e stack:** bring up `infra/docker-compose.e2e.yml` once on the prod box (`up -d` + `alembic upgrade head`).
6. **Confirm bundle ids** `me.ethanasm.vacation_price_tracker` / `me.ethanasm.vacation-price-tracker` match the Play/ASC app records before first submit.

### DB migrations
None in this PR. (The e2e stack runs the existing `alembic upgrade head` against its own isolated DB at bring-up.)

## Test plan
- [x] `node --test scripts/__tests__/bump-mobile-version.test.mjs` → 8/8 pass
- [x] Maestro flows validate: `node apps/mobile/e2e/scripts/dry-run.mjs apps/mobile/e2e/flows` → 4/4 OK (`appId=me.ethanasm.vacation_price_tracker`)
- [x] `actionlint` (Docker) clean on both `mobile-deploy.yml` and `mobile-e2e.yml`
- [x] `bash -n` clean on `mobile-deploy-failure-email.sh` and `setup-runner-android.sh`
- [x] `docker compose -f infra/docker-compose.e2e.yml config` valid
- [x] `eas.json` valid JSON; `expo config` resolves the real bundle id + updates URL; cleartext toggle true only under `EXPO_PUBLIC_E2E_MODE=1`
- [x] `pnpm verify` green
- [ ] First real `mobile-e2e` run is expected red until P3 merges (see Cross-plan dependency)
