### PR TITLE
fix(web): let the sign-in landing page scroll at narrow widths

### DIFF
--- a/apps/web/src/app/page.module.css
+++ b/apps/web/src/app/page.module.css
@@ -1,9 +1,10 @@
 .main {
   position: relative;
-  min-height: 100svh;
+  flex: 1;
+  min-height: 0;
   display: flex;
   flex-direction: column;
-  overflow: hidden;
+  overflow-y: auto;
   background: var(--aurora-page);
 }
 


### PR DESCRIPTION
## Summary

- The unauthenticated landing page `<main>` was locked to `min-height: 100svh; overflow: hidden` inside a `<body>` that is itself `height: 100vh; overflow: hidden`. At desktop width the two-column hero fits, but below the `820px` breakpoint the grid collapses to a single **stacked** column taller than the viewport — and with `overflow: hidden` nothing could scroll, so the "Sign in with Google" button sat below the fold and was **unreachable**. This is what made it impossible to sign in at half-width.
- Fix: make `<main>` a flex child (`flex: 1; min-height: 0`) that scrolls internally (`overflow-y: auto`). It still fills the viewport and vertically centers the hero when content fits, and now scrolls when content overflows (narrow widths, short viewports). Web-only change — the sign-in landing page has no mobile twin.

### Before / After (≈760px-wide window, below the 820px breakpoint)

| Before — sign-in button cut off, page won't scroll | After (top) | After (scrolled — button reachable) |
|---|---|---|
| ![before](https://github.com/ethanasm/vacation-price-tracker/raw/pr-screenshots/pr-assets/signin-narrow-before.png) | ![after-top](https://github.com/ethanasm/vacation-price-tracker/raw/pr-screenshots/pr-assets/signin-narrow-after-top.png) | ![after-scrolled](https://github.com/ethanasm/vacation-price-tracker/raw/pr-screenshots/pr-assets/signin-narrow-after-scrolled.png) |

## Test plan

- [x] `pnpm verify` green (build, lint, typecheck, test:coverage, security audits).
- [x] Reproduced at a ~760px-wide viewport: before the fix `main` reports `overflow-y: hidden` with content (933px) taller than the viewport (the Google button below the fold and unscrollable); after the fix `main` reports `overflow-y: auto` and the button scrolls into view.
- [x] Desktop (>820px) two-column layout unchanged — hero still vertically centered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VYyfS9aLu4g6JpoZRpjXmC)_