### PR TITLE
fix(api): exempt bearer-authenticated requests from CSRF

### DIFF
--- a/apps/api/app/middleware/csrf.py
+++ b/apps/api/app/middleware/csrf.py
@@ -45,6 +45,21 @@ def _is_csrf_exempt(path: str) -> bool:
     return path.startswith(CSRF_EXEMPT_PREFIXES)
 
 
+def _is_bearer_authenticated(request: Request) -> bool:
+    """True when the request carries an ``Authorization: Bearer`` credential.
+
+    Bearer-token clients (the mobile app) have no browser cookie session, so the
+    double-submit-cookie CSRF defense neither applies nor is forgeable: a browser
+    never auto-attaches a bearer header, and a cross-site request that tried to
+    set one would trip a CORS preflight the allowlist rejects. Exempting by auth
+    mechanism (not just by path) keeps every bearer-authed endpoint — POST
+    /v1/trips, the refresh/pause routes, etc. — reachable from mobile, while
+    cookie-authed (web) requests stay fully CSRF-protected.
+    """
+    auth = request.headers.get("Authorization", "")
+    return auth.startswith("Bearer ")
+
+
 def _ensure_csrf_cookie(response: Response, existing_token: str | None) -> None:
     if existing_token:
         return
@@ -58,7 +73,11 @@ def _ensure_csrf_cookie(response: Response, existing_token: str | None) -> None:
 
 async def csrf_middleware(request: Request, call_next):
     """Validate CSRF token for unsafe methods and set cookie on safe methods."""
-    if _needs_csrf_validation(request.method) and not _is_csrf_exempt(request.url.path):
+    if (
+        _needs_csrf_validation(request.method)
+        and not _is_csrf_exempt(request.url.path)
+        and not _is_bearer_authenticated(request)
+    ):
         csrf_cookie = request.cookies.get(CookieNames.CSRF_TOKEN)
         csrf_header = request.headers.get(HeaderNames.CSRF_TOKEN)
         if not csrf_cookie or not csrf_header or csrf_cookie != csrf_header:

--- a/apps/api/app/middleware/csrf.py
+++ b/apps/api/app/middleware/csrf.py
@@ -46,18 +46,32 @@ def _is_csrf_exempt(path: str) -> bool:
 
 
 def _is_bearer_authenticated(request: Request) -> bool:
-    """True when the request carries an ``Authorization: Bearer`` credential.
+    """True when the request carries an ``Authorization: Bearer <token>`` credential.
 
     Bearer-token clients (the mobile app) have no browser cookie session, so the
-    double-submit-cookie CSRF defense neither applies nor is forgeable: a browser
-    never auto-attaches a bearer header, and a cross-site request that tried to
-    set one would trip a CORS preflight the allowlist rejects. Exempting by auth
-    mechanism (not just by path) keeps every bearer-authed endpoint — POST
-    /v1/trips, the refresh/pause routes, etc. — reachable from mobile, while
-    cookie-authed (web) requests stay fully CSRF-protected.
+    double-submit-cookie CSRF defense neither applies nor is forgeable. The safety
+    of skipping CSRF here rests on the credentialed CORS allowlist
+    (``allow_credentials=True`` with an explicit single-origin list, see
+    ``app/main.py``): ``Authorization`` is not a CORS-safelisted header, so any
+    cross-origin request that sets it triggers a preflight an attacker origin
+    fails, and an HTML-form CSRF (the preflight-free vector) cannot set the header
+    at all. **If that CORS allowlist is ever loosened, this exemption re-opens CSRF
+    across the whole bearer surface.** Exempting by auth mechanism (not just by
+    path) keeps every bearer-authed endpoint — POST /v1/trips, the refresh/pause
+    routes, etc. — reachable from mobile, while cookie-authed (web) requests stay
+    fully CSRF-protected.
+
+    The scheme parse mirrors ``_extract_access_token`` in ``routers/auth.py``
+    (case-insensitive scheme, non-empty credential) so the set of CSRF-exempt
+    requests is exactly the set the authenticator treats as bearer-authed —
+    otherwise a ``bearer <jwt>`` request would authenticate but still be rejected
+    by CSRF, reproducing the opaque failure this guard exists to prevent.
     """
-    auth = request.headers.get("Authorization", "")
-    return auth.startswith("Bearer ")
+    auth_header = request.headers.get("Authorization")
+    if not auth_header:
+        return False
+    scheme, _, credential = auth_header.partition(" ")
+    return scheme.lower() == "bearer" and bool(credential)
 
 
 def _ensure_csrf_cookie(response: Response, existing_token: str | None) -> None:

--- a/apps/api/tests/test_auth_mobile.py
+++ b/apps/api/tests/test_auth_mobile.py
@@ -91,9 +91,19 @@ class TestSettingsAndCsrf:
             return Request({"type": "http", "headers": raw})
 
         assert _is_bearer_authenticated(_req({"Authorization": "Bearer abc.def.ghi"}))
+        # Scheme parse mirrors routers/auth.py: case-insensitive, non-empty credential.
+        assert _is_bearer_authenticated(_req({"Authorization": "bearer abc.def.ghi"}))
+        assert not _is_bearer_authenticated(_req({"Authorization": "Bearer "}))
+        assert not _is_bearer_authenticated(_req({"Authorization": "Bearer"}))
         # Cookie-authed (web) and other schemes are NOT exempt by this path.
         assert not _is_bearer_authenticated(_req({}))
         assert not _is_bearer_authenticated(_req({"Authorization": "Basic abc123"}))
+        # A cookie alongside a bearer is still exempt — the bearer presence wins
+        # here; cross-site forgery of that header is blocked by the credentialed
+        # CORS allowlist, not by CSRF (see csrf.py).
+        assert _is_bearer_authenticated(
+            _req({"Authorization": "Bearer abc.def.ghi", "Cookie": "csrf_token=x"})
+        )
 
 
 class TestMobileToken:

--- a/apps/api/tests/test_auth_mobile.py
+++ b/apps/api/tests/test_auth_mobile.py
@@ -79,6 +79,22 @@ class TestSettingsAndCsrf:
         # The web cookie endpoints are NOT exempt.
         assert not _is_csrf_exempt("/v1/auth/logout")
 
+    def test_bearer_requests_are_csrf_exempt_by_mechanism(self):
+        """Any Authorization: Bearer request is CSRF-exempt regardless of path —
+        the mobile app reaches non-/v1/auth write endpoints (POST /v1/trips, the
+        refresh/pause routes) with a bearer token and no cookie session."""
+        from app.middleware.csrf import _is_bearer_authenticated
+        from starlette.requests import Request
+
+        def _req(headers: dict[str, str]) -> Request:
+            raw = [(k.lower().encode(), v.encode()) for k, v in headers.items()]
+            return Request({"type": "http", "headers": raw})
+
+        assert _is_bearer_authenticated(_req({"Authorization": "Bearer abc.def.ghi"}))
+        # Cookie-authed (web) and other schemes are NOT exempt by this path.
+        assert not _is_bearer_authenticated(_req({}))
+        assert not _is_bearer_authenticated(_req({"Authorization": "Basic abc123"}))
+
 
 class TestMobileToken:
     @pytest.mark.asyncio

--- a/apps/api/tests/test_trips.py
+++ b/apps/api/tests/test_trips.py
@@ -105,6 +105,32 @@ async def test_create_trip_success(client_with_csrf, test_session, mock_redis, m
 
 
 @pytest.mark.asyncio
+async def test_create_trip_via_bearer_skips_csrf(client, test_session, mock_redis, monkeypatch):
+    """Mobile clients authenticate with `Authorization: Bearer` and carry no CSRF
+    cookie/header. Regression: every mobile write 500'd at the CSRF middleware
+    before reaching the endpoint; a bearer request must be CSRF-exempt and create
+    the trip."""
+    user = await _create_user(test_session, email="bearer-create@example.com")
+    token = create_access_token(data={JWTClaims.SUBJECT: str(user.id)})
+
+    monkeypatch.setattr(trips_module, "redis_client", mock_redis)
+    monkeypatch.setattr(trips_module, "trigger_price_check_workflow", AsyncMock())
+
+    # No CSRF cookie/header anywhere — only the bearer credential the mobile sends.
+    response = client.post(
+        "/v1/trips",
+        json=_build_trip_payload(name="Bearer Trip"),
+        headers={
+            "Authorization": f"Bearer {token}",
+            "X-Idempotency-Key": "trip-bearer-csrf-1",
+        },
+    )
+
+    assert response.status_code == 201, response.text
+    assert response.json()["data"]["name"] == "Bearer Trip"
+
+
+@pytest.mark.asyncio
 async def test_create_trip_one_way_success(client_with_csrf, test_session, mock_redis, monkeypatch):
     user = await _create_user(test_session, email="oneway@example.com")
     _authorize_client(client_with_csrf, user)


### PR DESCRIPTION
## Summary

- The CSRF middleware exempted the mobile **auth** endpoints (`/v1/auth/mobile-token`, `/v1/auth/refresh`) **by path**, but every *other* bearer-authed endpoint — `POST /v1/trips`, the refresh/pause/delete routes, etc. — still required a CSRF token. The mobile app authenticates with `Authorization: Bearer` and carries no cookie session, so it has no CSRF token: **every mobile write was rejected**, and because the rejection is raised inside middleware (outside the route's exception handler) it surfaced as an opaque **500** (`An unexpected error occurred`).
- Fix: exempt CSRF **by auth mechanism** instead of path — any `Authorization: Bearer <token>` request is CSRF-exempt. The double-submit-cookie defense neither applies nor is forgeable for bearer clients: the safety rests on the **credentialed CORS allowlist** (`allow_credentials=True` + explicit single origin) — `Authorization` is not a CORS-safelisted header, so a cross-origin request setting it fails preflight, and HTML-form CSRF can't set it at all. Cookie-authed (web) requests stay fully CSRF-protected. Mirrors the file's existing intent (it already exempts `/v1/admin/` and the mobile-token/refresh endpoints).
- The bearer scheme parse **mirrors `_extract_access_token` in `routers/auth.py`** (case-insensitive scheme, non-empty credential) so the CSRF-exempt set is exactly the set the authenticator treats as bearer-authed.
- This is a **live production bug**: the mobile app (P3) and bearer auth (P5) are already on `main`, so mobile create/update/pause/delete is broken in prod today — independent of the in-flight mobile PR.

Discovered via the mobile Maestro e2e on **#40**, where the captured `vpt-e2e-api` log showed `CsrfTokenInvalid` on `POST /v1/trips`.

## Deploy note

The mobile e2e on **#40 stays red until this lands**: that job's backend runs the prebuilt `ghcr.io/ethanasm/vpt-api:latest` (built on merge to `main`), not PR code. Once this merges, CI rebuilds `vpt-api:latest`; the `vpt-e2e` backend stack then needs a refresh (`docker compose --env-file .env.e2e -f infra/docker-compose.e2e.yml pull api worker && … up -d api worker`) to pick it up.

## Test plan

- [x] `nx run api:lint` — clean
- [x] `nx run api:test:coverage` — 1280 passed / 1 skipped, **96.21%** (≥95% gate)
- [x] Unit test `_is_bearer_authenticated`: true for `Bearer …` **and** case-insensitive `bearer …`; false for empty-credential `Bearer`, cookie-only, and `Basic`; cookie+bearer still exempt
- [x] Integration test: bearer-authed `POST /v1/trips` with **no** CSRF token succeeds (201)
- [x] Existing web cookie-auth CSRF tests still pass (no regression)

## Peer review

Opus peer-review: **approve-with-nits**, no P0/P1. Addressed **P2-b** (case-insensitive parse to match the authenticator) and the **P2-a/P2-c** hardening (CORS-safety comment + cookie+bearer test coverage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CLU2qzji7MCM2UREz8yaZR