### PR TITLE
fix(api): wipe synthetic user's trips on e2e mint-token

### DIFF
--- a/apps/api/app/routers/auth.py
+++ b/apps/api/app/routers/auth.py
@@ -434,6 +434,8 @@ async def e2e_mint_token(
         )
         raise AccessDenied("Invalid e2e token.")
 
+    from app.models.trip import Trip
+
     result = await db.execute(select(User).where(User.google_sub == E2E_SYNTHETIC_GOOGLE_SUB))
     user = result.scalars().first()
     if not user:
@@ -441,6 +443,15 @@ async def e2e_mint_token(
         db.add(user)
         await db.commit()
         await db.refresh(user)
+
+    # Reset the synthetic user's trip state so each e2e run starts from zero
+    # (mirrors the test-login wipe). Without it the mobile create-trip flow's
+    # fixed-name "Maestro Test Trip" collides on re-run (409 DuplicateTripName),
+    # and the per-user MAX_TRIPS_PER_USER cap is eventually hit. The mint step
+    # runs once per run before any flow, so trip-detail / trips-list still read
+    # the trip create-trip seeds within the same run.
+    await db.execute(delete(Trip).where(Trip.user_id == user.id))
+    await db.commit()
 
     jwt_data = _build_jwt_data(user.id)
     access_token = create_access_token(data=jwt_data)

--- a/apps/api/tests/test_auth_mobile.py
+++ b/apps/api/tests/test_auth_mobile.py
@@ -298,6 +298,39 @@ class TestE2eMintToken:
         assert len(rows) == 1
 
     @pytest.mark.asyncio
+    async def test_mint_wipes_existing_trips(self, client, test_session, monkeypatch):
+        """Each mint resets the synthetic user's trips so the create-trip e2e flow's
+        fixed-name "Maestro Test Trip" never collides (409 DuplicateTripName) on
+        re-run, and the MAX_TRIPS_PER_USER cap is never reached."""
+        import datetime as dt
+
+        from app.models.trip import Trip
+
+        monkeypatch.setattr(settings, "e2e_mode", True)
+        monkeypatch.setattr(settings, "vpt_e2e_backend_token", "s3cret-e2e-token")
+
+        # First mint upserts the synthetic user.
+        first = client.post("/v1/e2e/mint-token", headers={"X-E2E-Token": "s3cret-e2e-token"})
+        uid = uuid.UUID(first.json()["user"]["id"])
+
+        # Seed a trip for that user (simulating a prior run's create-trip).
+        trip = Trip(
+            user_id=uid, name="Maestro Test Trip", origin_airport="SEA",
+            destination_code="OGG", is_round_trip=False, depart_date=dt.date(2026, 8, 22),
+            return_date=None, adults=1, track_flights=True, track_hotels=True,
+        )
+        set_test_timestamps(trip)
+        test_session.add(trip)
+        await test_session.commit()
+
+        # A second mint must wipe it, leaving the create-trip flow a clean slate.
+        client.post("/v1/e2e/mint-token", headers={"X-E2E-Token": "s3cret-e2e-token"})
+        remaining = (
+            await test_session.execute(select(Trip).where(Trip.user_id == uid))
+        ).scalars().all()
+        assert remaining == []
+
+    @pytest.mark.asyncio
     async def test_missing_secret_header_403(self, client, monkeypatch):
         monkeypatch.setattr(settings, "e2e_mode", True)
         monkeypatch.setattr(settings, "vpt_e2e_backend_token", "s3cret-e2e-token")


### PR DESCRIPTION
## Summary

- The mobile e2e harness authenticates via **`POST /v1/e2e/mint-token`**, but — unlike `POST /v1/auth/test-login` — it never reset the synthetic e2e user's trips. So the create-trip Maestro flow's fixed-name **"Maestro Test Trip"** persisted in the e2e DB across runs, and re-creating it returned **409 `DuplicateTripName`** (and would eventually trip the per-user `MAX_TRIPS_PER_USER` cap).
- Fix: `e2e_mint_token` now wipes the synthetic user's trips (`delete(Trip).where(user_id == ...)`), mirroring the existing `test-login` wipe. The mint step runs **once per run, before any flow**, so trip-detail / trips-list still read the trip that create-trip seeds within the same run.
- This is e2e-only behavior: the endpoint is doubly gated (inert unless `E2E_MODE=1` **and** the `X-E2E-Token` secret matches), so it never affects prod.

Surfaced by **#40**'s mobile Maestro e2e: once the CSRF and `trip-card` testID fixes landed, sign-in / trip-detail / trips-list all pass and only create-trip failed — `POST /v1/trips → 409 Conflict` in the captured `vpt-e2e-api.log`.

## Deploy note

Like the CSRF fix (#44), #40's e2e backend runs the prebuilt `ghcr.io/ethanasm/vpt-api:latest`, so this must merge → rebuild `vpt-api:latest` → refresh the `vpt-e2e` stack (`docker compose --env-file .env.e2e -f infra/docker-compose.e2e.yml pull api worker && … up -d api worker`) before #40's create-trip flow goes green.

## Test plan

- [x] `nx run api:lint` — clean
- [x] `nx run api:test:coverage` — green (≥95% gate)
- [x] New test `test_mint_wipes_existing_trips`: seed a trip for the synthetic user, mint again, assert the trip is wiped
- [x] Existing mint-token tests (inert-when-off, secret checks, user upsert/reuse) still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CLU2qzji7MCM2UREz8yaZR

---
_Generated by [Claude Code](https://claude.ai/code/session_011XfGzSh4zKSnYqf5A3cxdS)_